### PR TITLE
refactor: Rename openApiRoute to openApiMeta for better semantic clarity

### DIFF
--- a/packages/kori-example/src/getting-started.ts
+++ b/packages/kori-example/src/getting-started.ts
@@ -1,7 +1,7 @@
 import { createKori } from 'kori';
 import { startNodeServer } from 'kori-nodejs-adapter';
 import { scalarUIPlugin } from 'kori-openapi-ui-scalar';
-import { zodOpenApiPlugin, openApiRoute } from 'kori-zod-openapi-plugin';
+import { zodOpenApiPlugin, openApiMeta } from 'kori-zod-openapi-plugin';
 import { zodRequest } from 'kori-zod-schema';
 import { createKoriZodRequestValidator, createKoriZodResponseValidator } from 'kori-zod-validator';
 import { z } from 'zod';
@@ -37,7 +37,7 @@ const app = createKori({
 
 // Basic route
 app.get('/hello/:name', {
-  pluginMetadata: openApiRoute({
+  pluginMetadata: openApiMeta({
     summary: 'Say hello',
     description: 'Returns a personalized greeting',
     tags: ['Basic'],
@@ -53,7 +53,7 @@ app.get('/hello/:name', {
 
 // CRUD operations with validation
 app.post('/users', {
-  pluginMetadata: openApiRoute({
+  pluginMetadata: openApiMeta({
     summary: 'Create user',
     description: 'Create a new user with validation',
     tags: ['Users'],
@@ -74,7 +74,7 @@ app.post('/users', {
 });
 
 app.get('/users', {
-  pluginMetadata: openApiRoute({
+  pluginMetadata: openApiMeta({
     summary: 'List users',
     description: 'Get all users',
     tags: ['Users'],
@@ -93,7 +93,7 @@ app.createChild({
   prefix: '/api/v1',
   configure: (k) =>
     k.get('/status', {
-      pluginMetadata: openApiRoute({
+      pluginMetadata: openApiMeta({
         summary: 'API v1 Status',
         description: 'Get API version 1 status',
         tags: ['API v1'],
@@ -111,7 +111,7 @@ app.createChild({
   prefix: '/api/v2',
   configure: (k) =>
     k.get('/status', {
-      pluginMetadata: openApiRoute({
+      pluginMetadata: openApiMeta({
         summary: 'API v2 Status',
         description: 'Get API version 2 status',
         tags: ['API v2'],

--- a/packages/kori-example/src/usage.ts
+++ b/packages/kori-example/src/usage.ts
@@ -2,7 +2,7 @@
 import { createKori, defineKoriPlugin, type KoriEnvironment, type KoriRequest, type KoriResponse } from 'kori';
 import { startNodeServer } from 'kori-nodejs-adapter';
 import { scalarUIPlugin } from 'kori-openapi-ui-scalar';
-import { zodOpenApiPlugin, openApiRoute } from 'kori-zod-openapi-plugin';
+import { zodOpenApiPlugin, openApiMeta } from 'kori-zod-openapi-plugin';
 import { zodRequest } from 'kori-zod-schema';
 import { createKoriZodRequestValidator, createKoriZodResponseValidator } from 'kori-zod-validator';
 import { z } from 'zod';
@@ -125,17 +125,17 @@ const app = createKori({
 
 // Complex validation example
 app.post('/products', {
+  pluginMetadata: openApiMeta({
+    summary: 'Create product',
+    description: 'Create a product with complex validation',
+    tags: ['Products'],
+  }),
   requestSchema: zodRequest({
     body: ProductSchema,
     headers: z.object({
       'x-api-version': z.enum(['1.0', '2.0']).optional(),
       'x-client-id': z.string().min(1).describe('Client identifier'),
     }),
-  }),
-  pluginMetadata: openApiRoute({
-    summary: 'Create product',
-    description: 'Create a product with complex validation',
-    tags: ['Products'],
   }),
   handler: (ctx) => {
     const product = ctx.req.validated.body;
@@ -160,6 +160,11 @@ app.post('/products', {
 
 // Search with complex query validation
 app.get('/products/search', {
+  pluginMetadata: openApiMeta({
+    summary: 'Search products',
+    description: 'Advanced product search with filtering',
+    tags: ['Products'],
+  }),
   requestSchema: zodRequest({
     queries: z.object({
       q: z.string().min(1).describe('Search query'),
@@ -178,11 +183,6 @@ app.get('/products/search', {
       sort: z.enum(['name', 'price', 'created']).default('name'),
       order: z.enum(['asc', 'desc']).default('asc'),
     }),
-  }),
-  pluginMetadata: openApiRoute({
-    summary: 'Search products',
-    description: 'Advanced product search with filtering',
-    tags: ['Products'],
   }),
   handler: (ctx) => {
     const query = ctx.req.validated.queries;
@@ -231,7 +231,7 @@ app.createChild({
         }
       })
       .get('/dashboard', {
-        pluginMetadata: openApiRoute({
+        pluginMetadata: openApiMeta({
           summary: 'Admin dashboard',
           description: 'Get admin dashboard data (requires auth)',
           tags: ['Admin'],
@@ -248,16 +248,16 @@ app.createChild({
           }),
       })
       .post('/maintenance', {
+        pluginMetadata: openApiMeta({
+          summary: 'Toggle maintenance mode',
+          description: 'Enable or disable maintenance mode',
+          tags: ['Admin'],
+        }),
         requestSchema: zodRequest({
           body: z.object({
             mode: z.enum(['enable', 'disable']),
             reason: z.string().optional(),
           }),
-        }),
-        pluginMetadata: openApiRoute({
-          summary: 'Toggle maintenance mode',
-          description: 'Enable or disable maintenance mode',
-          tags: ['Admin'],
         }),
         handler: (ctx) => {
           const { mode, reason } = ctx.req.validated.body;
@@ -280,7 +280,7 @@ app.createChild({
 
 // Health check with detailed info
 app.get('/health', {
-  pluginMetadata: openApiRoute({
+  pluginMetadata: openApiMeta({
     summary: 'Health check',
     description: 'Detailed health information',
     tags: ['System'],
@@ -297,7 +297,7 @@ app.get('/health', {
 
 // Error demonstration
 app.get('/error/:type', {
-  pluginMetadata: openApiRoute({
+  pluginMetadata: openApiMeta({
     summary: 'Error demo',
     description: 'Demonstrate different error types',
     tags: ['Demo'],

--- a/packages/kori-openapi-plugin/src/index.ts
+++ b/packages/kori-openapi-plugin/src/index.ts
@@ -1,9 +1,9 @@
 export {
   type OpenApiEnvironmentExtension,
+  openApiMeta,
   OpenApiMetaSymbol,
   type OpenApiOptions,
   openApiPlugin,
-  openApiRoute,
   type OpenApiRouteMeta,
 } from './openapi-plugin.js';
 export {

--- a/packages/kori-openapi-plugin/src/openapi-plugin.ts
+++ b/packages/kori-openapi-plugin/src/openapi-plugin.ts
@@ -42,7 +42,7 @@ export type OpenApiOptions = {
   converters: AtLeastOneConverter;
 };
 
-export function openApiRoute(meta: OpenApiRouteMeta): KoriRoutePluginMetadata {
+export function openApiMeta(meta: OpenApiRouteMeta): KoriRoutePluginMetadata {
   return {
     [OpenApiMetaSymbol]: meta,
   };

--- a/packages/kori-zod-openapi-plugin/src/index.ts
+++ b/packages/kori-zod-openapi-plugin/src/index.ts
@@ -12,4 +12,4 @@ export function zodOpenApiPlugin(options: ZodOpenApiOptions): ReturnType<typeof 
 }
 
 export { createZodSchemaConverter } from './converter.js';
-export { openApiRoute } from 'kori-openapi-plugin';
+export { openApiMeta } from 'kori-openapi-plugin';


### PR DESCRIPTION
## Overview
This PR renames `openApiRoute` to `openApiMeta` across the codebase to improve semantic accuracy and API clarity.

## Changes Made

### 🔧 API Renaming
- **`openApiRoute` → `openApiMeta`** for better semantic accuracy
  - The function doesn't create routes; it provides metadata for OpenAPI documentation
  - `openApiMeta` more accurately describes its purpose
  - Maintains the same functionality with clearer naming

### 📁 Files Modified
- `packages/kori-openapi-plugin/src/openapi-plugin.ts` - Updated function name
- `packages/kori-openapi-plugin/src/index.ts` - Updated export
- `packages/kori-zod-openapi-plugin/src/index.ts` - Updated re-export
- `packages/kori-example/src/getting-started.ts` - Updated all usage instances (6 changes)
- `packages/kori-example/src/usage.ts` - Updated all usage instances (19 changes)

### 📊 Changes Summary
5 files changed, 28 insertions(+), 28 deletions(-)

## Benefits
- **Improved API Design**: Function name now accurately reflects its purpose
- **Better Developer Experience**: Less confusion about what the function does
- **Semantic Consistency**: Aligns with the actual behavior (metadata provision, not route creation)
- **Future-Proof**: Clearer naming reduces misunderstandings in future development

## Breaking Change
⚠️ This is a breaking change for users currently using `openApiRoute`. The function has been completely renamed to `openApiMeta` with no backward compatibility layer.

## Testing
- ✅ All packages build successfully
- ✅ All examples work correctly with the new API
- ✅ No functional changes, only naming improvements