### PR TITLE
fix(nodejs-adapter): forward callback to server.listen in createNodeApp.listen

### DIFF
--- a/packages/kori-nodejs-adapter/src/index.ts
+++ b/packages/kori-nodejs-adapter/src/index.ts
@@ -95,7 +95,7 @@ export async function startNodeServer<
   ResponseValidator extends KoriResponseValidatorDefault | undefined,
 >(
   kori: Kori<Env, Req, Res, RequestValidator, ResponseValidator>,
-  options: { port?: number; host?: string } = {},
+  options: { port?: number; host?: string; callback?: () => void } = {},
 ): Promise<void> {
   const port = options.port || 3000;
   const host = options.host || 'localhost';
@@ -135,6 +135,7 @@ export async function startNodeServer<
   // Start server
   server.listen(port, host, () => {
     kori.log.info(`Kori server started at http://${host}:${port}`);
+    if (options.callback) options.callback();
   });
 
   // Shutdown processing
@@ -154,8 +155,7 @@ export function createNodeApp<
 >(kori: Kori<Env, Req, Res, RequestValidator, ResponseValidator>) {
   return {
     listen(port = 3000, host = 'localhost', callback?: () => void) {
-      startNodeServer(kori, { port, host });
-      if (callback) callback();
+      startNodeServer(kori, { port, host, callback });
     },
   };
 }

--- a/packages/kori-nodejs-adapter/src/index.ts
+++ b/packages/kori-nodejs-adapter/src/index.ts
@@ -135,7 +135,15 @@ export async function startNodeServer<
   await new Promise<void>((resolve, reject) => {
     server.listen(port, host, () => {
       kori.log.info(`Kori server started at http://${host}:${port}`);
-      if (options.callback) options.callback();
+      if (options.callback) {
+        try {
+          options.callback();
+        } catch (error) {
+          // Log the error but don't prevent the Promise from resolving
+          // The server has successfully started regardless of callback errors
+          kori.log.error('Error in callback', { err: error });
+        }
+      }
       resolve();
     });
 

--- a/packages/kori-nodejs-adapter/src/index.ts
+++ b/packages/kori-nodejs-adapter/src/index.ts
@@ -131,10 +131,17 @@ export async function startNodeServer<
     }
   });
 
-  // Start server
-  server.listen(port, host, () => {
-    kori.log.info(`Kori server started at http://${host}:${port}`);
-    if (options.callback) options.callback();
+  // Start server and wait for it to be ready
+  await new Promise<void>((resolve, reject) => {
+    server.listen(port, host, () => {
+      kori.log.info(`Kori server started at http://${host}:${port}`);
+      if (options.callback) options.callback();
+      resolve();
+    });
+
+    server.on('error', (error) => {
+      reject(error);
+    });
   });
 
   // Shutdown processing

--- a/packages/kori-nodejs-adapter/src/index.ts
+++ b/packages/kori-nodejs-adapter/src/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-floating-promises */
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 /* eslint-disable @typescript-eslint/no-misused-promises */
 /* eslint-disable @typescript-eslint/prefer-nullish-coalescing */
@@ -154,8 +153,8 @@ export function createNodeApp<
   ResponseValidator extends KoriResponseValidatorDefault | undefined,
 >(kori: Kori<Env, Req, Res, RequestValidator, ResponseValidator>) {
   return {
-    listen(port = 3000, host = 'localhost', callback?: () => void) {
-      startNodeServer(kori, { port, host, callback });
+    listen(port = 3000, host = 'localhost', callback?: () => void): Promise<void> {
+      return startNodeServer(kori, { port, host, callback });
     },
   };
 }

--- a/packages/kori-openapi-ui-scalar/src/scalar-ui-plugin.ts
+++ b/packages/kori-openapi-ui-scalar/src/scalar-ui-plugin.ts
@@ -70,7 +70,8 @@ function generateScalarHTML(options: ScalarHTMLOptions): string {
   const customCssTag = options.customCss ? `<style>${options.customCss}</style>` : '';
   const proxyUrlConfig = options.proxyUrl ? `proxyUrl: '${options.proxyUrl}',` : '';
 
-  return `<!DOCTYPE html>
+  return `
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8" />
@@ -89,5 +90,6 @@ function generateScalarHTML(options: ScalarHTMLOptions): string {
     });
   </script>
 </body>
-</html>`;
+</html>
+`;
 }

--- a/packages/kori-openapi-ui-scalar/src/scalar-ui-plugin.ts
+++ b/packages/kori-openapi-ui-scalar/src/scalar-ui-plugin.ts
@@ -89,6 +89,5 @@ function generateScalarHTML(options: ScalarHTMLOptions): string {
     });
   </script>
 </body>
-</html>
-`;
+</html>`;
 }

--- a/packages/kori-openapi-ui-scalar/src/scalar-ui-plugin.ts
+++ b/packages/kori-openapi-ui-scalar/src/scalar-ui-plugin.ts
@@ -70,8 +70,7 @@ function generateScalarHTML(options: ScalarHTMLOptions): string {
   const customCssTag = options.customCss ? `<style>${options.customCss}</style>` : '';
   const proxyUrlConfig = options.proxyUrl ? `proxyUrl: '${options.proxyUrl}',` : '';
 
-  return `
-<!DOCTYPE html>
+  return `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8" />


### PR DESCRIPTION
## Description

Fixed an issue where the optional callback parameter in `createNodeApp.listen()` was called immediately instead of being forwarded to the underlying `server.listen()` callback.

## Changes

- Added `callback?: () => void` parameter to `startNodeServer` options
- Modified `server.listen()` to call the callback after the server actually starts listening
- Updated `createNodeApp.listen()` to properly forward the callback to `startNodeServer`
- Removed the problematic immediate callback invocation

## Before

```typescript
listen(port = 3000, host = 'localhost', callback?: () => void) {
  startNodeServer(kori, { port, host });
  if (callback) callback(); // Called immediately, before server starts
}
```

## After

```typescript
listen(port = 3000, host = 'localhost', callback?: () => void) {
  startNodeServer(kori, { port, host, callback }); // Properly forwarded
}
```

## Impact

- The callback now behaves consistently with Node.js's standard `server.listen()` behavior
- Fixes potential timing issues where code in the callback might execute before the server is ready
- No breaking changes - existing code without callbacks continues to work as before