### PR TITLE
Implement exclusion feature in OpenAPI plugin

### DIFF
--- a/packages/kori-openapi-plugin/tsconfig.json
+++ b/packages/kori-openapi-plugin/tsconfig.json
@@ -7,7 +7,5 @@
   },
   "include": ["src/**/*"],
   "exclude": ["src/**/*.test.ts"],
-  "references": [
-    { "path": "../kori" }
-  ]
+  "references": [{ "path": "../kori" }]
 }

--- a/packages/kori-openapi-ui-scalar/src/scalar-ui-plugin.ts
+++ b/packages/kori-openapi-ui-scalar/src/scalar-ui-plugin.ts
@@ -33,9 +33,7 @@ export function scalarUiPlugin<
       const uiPath = options.path ?? '/docs';
       const title = options.title ?? 'API Documentation';
 
-      kori.addRoute({
-        method: 'GET',
-        path: uiPath,
+      kori.get(uiPath, {
         handler: (ctx) => {
           const documentPath = ctx.env.openapi?.documentPath;
           if (!documentPath) {

--- a/packages/kori-openapi-ui-scalar/src/scalar-ui-plugin.ts
+++ b/packages/kori-openapi-ui-scalar/src/scalar-ui-plugin.ts
@@ -1,5 +1,5 @@
 import { defineKoriPlugin, type KoriPlugin, type KoriResponse, type KoriRequest, type KoriEnvironment } from 'kori';
-import { type OpenApiEnvironmentExtension } from 'kori-openapi-plugin';
+import { type OpenApiEnvironmentExtension, openApiMeta } from 'kori-openapi-plugin';
 
 export type ScalarUiOptions = {
   path?: string;
@@ -51,6 +51,7 @@ export function scalarUiPlugin<
           });
           return ctx.res.html(html);
         },
+        pluginMetadata: openApiMeta({ exclude: true }),
       });
 
       return kori;

--- a/packages/kori/src/kori/route-handler-factory.ts
+++ b/packages/kori/src/kori/route-handler-factory.ts
@@ -12,15 +12,15 @@ import {
   type KoriOnFinallyHook,
 } from '../hook/index.js';
 import {
-	resolveRequestValidationFunction,
-	type InferRequestValidatorError,
-	type KoriRequestValidatorDefault,
-	type WithValidatedRequest,
+  resolveRequestValidationFunction,
+  type InferRequestValidatorError,
+  type KoriRequestValidatorDefault,
+  type WithValidatedRequest,
 } from '../request-validation/index.js';
 import {
-	resolveResponseValidationFunction,
-	type KoriResponseValidatorDefault,
-	type InferResponseValidationError,
+  resolveResponseValidationFunction,
+  type KoriResponseValidatorDefault,
+  type InferResponseValidationError,
 } from '../response-validation/index.js';
 import { type KoriRouterHandler, type WithPathParams } from '../router/index.js';
 import { type KoriRequestSchemaDefault, type KoriResponseSchemaDefault } from '../schema/index.js';


### PR DESCRIPTION
Add an `exclude` option to OpenAPI metadata to control which routes appear in the documentation.

This feature replaces the less flexible `excludePaths` option with a metadata-driven approach. It allows individual routes to be marked for exclusion and automatically hides the OpenAPI document and UI endpoints from the generated documentation. A development warning is also added for conflicting metadata usage.