### PR TITLE
feat: Implement brand-based schema identification for better type safety

### DIFF
--- a/packages/kori-zod-openapi-plugin/src/converter.ts
+++ b/packages/kori-zod-openapi-plugin/src/converter.ts
@@ -1,15 +1,8 @@
-import { type KoriSchemaDefault, isKoriSchema } from 'kori';
+import { type KoriSchemaDefault } from 'kori';
 import { type SchemaConverter, type ConversionContext } from 'kori-openapi-plugin';
-import { type KoriZodSchema } from 'kori-zod-schema';
+import { isKoriZodSchema } from 'kori-zod-schema';
 import { type SchemaObject } from 'openapi3-ts/oas31';
 import { z } from 'zod/v4';
-
-/**
- * Check if a schema is a Kori Zod schema
- */
-function isKoriZodSchema(schema: KoriSchemaDefault): schema is KoriZodSchema<z.ZodType> {
-  return isKoriSchema(schema) && 'def' in schema && typeof schema.def === 'object' && schema.def !== null;
-}
 
 /**
  * Create a Zod schema converter for OpenAPI

--- a/packages/kori-zod-schema/src/index.ts
+++ b/packages/kori-zod-schema/src/index.ts
@@ -2,6 +2,7 @@ export { type KoriZodRequestParts, type KoriZodRequestSchema, zodRequest } from 
 export { type KoriZodResponseSchema, zodResponse } from './zod-response-schema.js';
 export {
   createKoriZodSchema,
+  isKoriZodSchema,
   type KoriZodSchema,
   type KoriZodSchemaDefault,
   type KoriZodSchemaProvider,

--- a/packages/kori-zod-schema/src/zod-schema.ts
+++ b/packages/kori-zod-schema/src/zod-schema.ts
@@ -1,5 +1,7 @@
-import { type KoriSchema, type KoriSchemaProvider, createKoriSchema } from 'kori';
+import { type KoriSchema, type KoriSchemaProvider, createKoriSchema, isKoriSchema, getKoriSchemaBrand } from 'kori';
 import { type z } from 'zod/v4';
+
+const ZodSchemaBrand = Symbol('zod-schema-brand');
 
 export type KoriZodSchemaProvider = KoriSchemaProvider<'zod'>;
 
@@ -8,5 +10,10 @@ export type KoriZodSchema<T extends z.ZodType> = KoriSchema<T, z.output<T>>;
 export type KoriZodSchemaDefault = KoriZodSchema<z.ZodType>;
 
 export const createKoriZodSchema = <T extends z.ZodType>(schema: T): KoriZodSchema<T> => {
-  return createKoriSchema(schema);
+  return createKoriSchema(ZodSchemaBrand, schema);
 };
+
+export function isKoriZodSchema(value: unknown): value is KoriZodSchemaDefault {
+  if (!isKoriSchema(value)) return false;
+  return getKoriSchemaBrand(value) === ZodSchemaBrand;
+}

--- a/packages/kori/src/index.ts
+++ b/packages/kori/src/index.ts
@@ -77,6 +77,7 @@ export {
 } from './router/index.js';
 export {
   createKoriSchema,
+  getKoriSchemaBrand,
   type InferRequestSchemaProvider,
   type InferResponseSchemaProvider,
   type InferSchemaOutput,

--- a/packages/kori/src/schema/index.ts
+++ b/packages/kori/src/schema/index.ts
@@ -27,6 +27,7 @@ export {
 } from './response-schema.js';
 export {
   createKoriSchema,
+  getKoriSchemaBrand,
   type InferSchemaOutput,
   isKoriSchema,
   type KoriSchema,

--- a/packages/kori/src/schema/schema.ts
+++ b/packages/kori/src/schema/schema.ts
@@ -2,7 +2,7 @@ const Brand = Symbol('schema-brand');
 const OutputProp = Symbol('schema-output-prop');
 
 export type KoriSchema<Def, Out> = {
-  readonly [Brand]: typeof Brand;
+  readonly [Brand]: symbol;
   readonly def: Def;
   readonly [OutputProp]?: Out;
 };
@@ -13,11 +13,15 @@ export function isKoriSchema(value: unknown): value is KoriSchemaDefault {
   return typeof value === 'object' && value !== null && Brand in value;
 }
 
+export function getKoriSchemaBrand(schema: KoriSchemaDefault): symbol {
+  return schema[Brand];
+}
+
 export type InferSchemaOutput<S> = S extends KoriSchema<infer _Def, infer Out> ? Out : never;
 
-export function createKoriSchema<Def, Out>(def: Def): KoriSchema<Def, Out> {
+export function createKoriSchema<Def, Out>(brand: symbol, def: Def): KoriSchema<Def, Out> {
   return {
-    [Brand]: Brand,
+    [Brand]: brand,
     def,
   };
 }


### PR DESCRIPTION
## Summary

This PR implements a brand-based schema identification system for `KoriSchema`, replacing the previous ambiguous type checking mechanism with a robust symbol-based approach.

## Changes

### Core Schema Changes
- **Modified `KoriSchema` type**: Changed from `readonly [Brand]: typeof Brand` to `readonly [Brand]: symbol` to support provider-specific brands
- **Updated `createKoriSchema`**: Now accepts a `brand: symbol` as the first parameter to identify schema providers
- **Added `getKoriSchemaBrand`**: New function to safely retrieve the brand from a schema instance

### Zod Schema Improvements
- **Introduced `ZodSchemaBrand`**: Dedicated symbol for Zod schema identification
- **Enhanced `isKoriZodSchema`**: Replaced unsafe type checking with reliable brand comparison:
  ```typescript
  // Before (unsafe)
  return isKoriSchema(schema) && 'def' in schema && typeof schema.def === 'object' && schema.def !== null;
  
  // After (safe)
  if (!isKoriSchema(value)) return false;
  return getKoriSchemaBrand(value) === ZodSchemaBrand;
  ```

## Benefits

1. **Type Safety**: Eliminates false positives in schema type detection
2. **Extensibility**: Enables easy addition of new schema providers (Joi, Yup, etc.) with the same pattern
3. **Performance**: Simple symbol comparison instead of property inspection
4. **Maintainability**: Clear separation between different schema providers

## Breaking Changes

⚠️ **Breaking Change**: `createKoriSchema` signature changed from `createKoriSchema<Def, Out>(def: Def)` to `createKoriSchema<Def, Out>(brand: symbol, def: Def)`

## Future Impact

This foundation allows for consistent implementation of additional schema providers:
```typescript
// Future providers can follow the same pattern
const JoiSchemaBrand = Symbol('joi-schema-brand');
export const createKoriJoiSchema = (schema) => createKoriSchema(JoiSchemaBrand, schema);
export const isKoriJoiSchema = (value) => isKoriSchema(value) && getKoriSchemaBrand(value) === JoiSchemaBrand;
```
```