### PR TITLE
Rename zodRequest to zodRequestSchema and zodResponse to zodResponseSchema for clarity

### DIFF
--- a/packages/kori-example/src/getting-started.ts
+++ b/packages/kori-example/src/getting-started.ts
@@ -2,7 +2,7 @@ import { createKori } from 'kori';
 import { startNodeServer } from 'kori-nodejs-adapter';
 import { scalarUiPlugin } from 'kori-openapi-ui-scalar';
 import { zodOpenApiPlugin, openApiMeta } from 'kori-zod-openapi-plugin';
-import { zodRequest } from 'kori-zod-schema';
+import { zodRequestSchema } from 'kori-zod-schema';
 import { createKoriZodRequestValidator, createKoriZodResponseValidator } from 'kori-zod-validator';
 import { z } from 'zod/v4';
 
@@ -54,7 +54,7 @@ app.post('/users', {
     description: 'Create a new user with validation',
     tags: ['Users'],
   }),
-  requestSchema: zodRequest({
+  requestSchema: zodRequestSchema({
     body: UserSchema,
   }),
   handler: (ctx) => {

--- a/packages/kori-example/src/usage.ts
+++ b/packages/kori-example/src/usage.ts
@@ -4,7 +4,7 @@ import { startNodeServer } from 'kori-nodejs-adapter';
 import { scalarUiPlugin } from 'kori-openapi-ui-scalar';
 import { createPinoKoriLoggerFactory } from 'kori-pino-adapter';
 import { zodOpenApiPlugin, openApiMeta } from 'kori-zod-openapi-plugin';
-import { zodRequest } from 'kori-zod-schema';
+import { zodRequestSchema } from 'kori-zod-schema';
 import { createKoriZodRequestValidator, createKoriZodResponseValidator } from 'kori-zod-validator';
 import { z } from 'zod/v4';
 
@@ -126,7 +126,7 @@ app.post('/products', {
     description: 'Create a product with complex validation',
     tags: ['Products'],
   }),
-  requestSchema: zodRequest({
+  requestSchema: zodRequestSchema({
     body: ProductSchema,
     headers: z.object({
       'x-api-version': z.enum(['1.0', '2.0']).optional(),
@@ -160,7 +160,7 @@ app.get('/products/search', {
     description: 'Advanced product search with filtering',
     tags: ['Products'],
   }),
-  requestSchema: zodRequest({
+  requestSchema: zodRequestSchema({
     queries: z.object({
       q: z.string().min(1).meta({ description: 'Search query' }),
       category: z.enum(['electronics', 'books', 'clothing']).optional(),
@@ -247,7 +247,7 @@ app.createChild({
           description: 'Enable or disable maintenance mode',
           tags: ['Admin'],
         }),
-        requestSchema: zodRequest({
+        requestSchema: zodRequestSchema({
           body: z.object({
             mode: z.enum(['enable', 'disable']),
             reason: z.string().optional(),

--- a/packages/kori-zod-schema/src/index.ts
+++ b/packages/kori-zod-schema/src/index.ts
@@ -1,5 +1,5 @@
-export { type KoriZodRequestParts, type KoriZodRequestSchema, zodRequest } from './zod-request-schema.js';
-export { type KoriZodResponseSchema, zodResponse } from './zod-response-schema.js';
+export { type KoriZodRequestParts, type KoriZodRequestSchema, zodRequestSchema } from './zod-request-schema.js';
+export { type KoriZodResponseSchema, zodResponseSchema } from './zod-response-schema.js';
 export {
   createKoriZodSchema,
   isKoriZodSchema,

--- a/packages/kori-zod-schema/src/zod-request-schema.ts
+++ b/packages/kori-zod-schema/src/zod-request-schema.ts
@@ -27,11 +27,9 @@ export type KoriZodRequestBodySchema =
   | KoriRequestSchemaContent<KoriZodSchema<z.ZodType>>
   | KoriRequestSchemaBody<KoriZodSchema<z.ZodType>>;
 
-// Convert raw zod schema to wrapped schema type
 type ToKoriZodSchema<T extends z.ZodType> = KoriZodSchema<T>;
 
-// Main zodRequest function with proper type inference
-export function zodRequest<
+export function zodRequestSchema<
   TParams extends z.ZodType | undefined = undefined,
   THeaders extends z.ZodType | undefined = undefined,
   TQueries extends z.ZodType | undefined = undefined,

--- a/packages/kori-zod-schema/src/zod-response-schema.ts
+++ b/packages/kori-zod-schema/src/zod-response-schema.ts
@@ -5,7 +5,7 @@ import { type KoriZodSchema, type KoriZodSchemaProvider } from './zod-schema.js'
 
 export type KoriZodResponseSchema<S extends KoriZodSchema<z.ZodType>> = KoriResponseSchema<KoriZodSchemaProvider, S>;
 
-export function zodResponse<S extends KoriZodSchema<z.ZodType>>(
+export function zodResponseSchema<S extends KoriZodSchema<z.ZodType>>(
   schema: KoriResponseSchemaStructure<S>,
 ): KoriZodResponseSchema<S> {
   return schema;

--- a/turbo.json
+++ b/turbo.json
@@ -5,6 +5,10 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**"]
     },
+    "kori-example#build": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
     "typecheck": {
       "dependsOn": ["^typecheck"]
     },


### PR DESCRIPTION
## Summary

Renamed functions in the `kori-zod-schema` package to improve API clarity and make their purpose more explicit.

## Changes

### 🔄 Function Renames
- `zodRequest` → `zodRequestSchema`
- `zodResponse` → `zodResponseSchema`

This makes it clearer that these functions create request/response schemas rather than handling requests directly.

### 📦 Impact Scope
- **kori-zod-schema**: Updated export function names
- **kori-example**: Updated to use new function names (4 locations)

### 🔧 Additional Improvements
- **turbo.json**: Added `kori-example#build` task with `outputs: []` to resolve unnecessary build warnings

## Breaking Changes

✅ **Breaking Change**: Existing code using `zodRequest` / `zodResponse` must be updated to use the new function names.

### Migration Guide
```typescript
// Before
import { zodRequest, zodResponse } from 'kori-zod-schema';

// After  
import { zodRequestSchema, zodResponseSchema } from 'kori-zod-schema';
```

## Testing

- [x] Verified both kori-example files work correctly
- [x] TypeScript type checking passes
- [x] Build warnings resolved