### PR TITLE
Update plugin definitions to new type inference

### DIFF
--- a/packages/kori-openapi-plugin/src/openapi-plugin.ts
+++ b/packages/kori-openapi-plugin/src/openapi-plugin.ts
@@ -1,5 +1,5 @@
 import {
-  defineKoriRawPlugin,
+  defineKoriPlugin,
   type KoriRoutePluginMetadata,
   type KoriPlugin,
   type KoriResponse,
@@ -97,20 +97,20 @@ export function openApiPlugin<Env extends KoriEnvironment, Req extends KoriReque
     return cachedDocument;
   }
 
-  return defineKoriRawPlugin({
+  return defineKoriPlugin({
     name: 'openapi',
     version: '1.0.0',
     apply: (kori) => {
       // Add OpenAPI document endpoint
       kori.get(documentPath, {
-        handler: (ctx) => {
+        handler: (ctx: any) => {
           const doc = generateDocument();
           return ctx.res.json(doc);
         },
         pluginMetadata: openApiMeta({ exclude: true }),
       });
 
-      return kori.onInit((ctx) => {
+      return kori.onInit((ctx: any) => {
         // Collect route metadata from the kori instance (after all routes are registered)
         const routeDefinitions = kori.routeDefinitions();
         for (const routeDef of routeDefinitions) {

--- a/packages/kori-openapi-ui-scalar/src/scalar-ui-plugin.ts
+++ b/packages/kori-openapi-ui-scalar/src/scalar-ui-plugin.ts
@@ -1,4 +1,4 @@
-import { defineKoriRawPlugin, type KoriPlugin, type KoriResponse, type KoriRequest, type KoriEnvironment } from 'kori';
+import { defineKoriPlugin, type KoriPlugin, type KoriResponse, type KoriRequest, type KoriEnvironment } from 'kori';
 import { type OpenApiEnvironmentExtension, openApiMeta } from 'kori-openapi-plugin';
 
 export type ScalarUiOptions = {
@@ -27,14 +27,14 @@ export function scalarUiPlugin<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   any
 > {
-  return defineKoriRawPlugin({
+  return defineKoriPlugin({
     name: 'openapi-ui-scalar',
-    apply(kori) {
+    apply: (kori) => {
       const uiPath = options.path ?? '/docs';
       const title = options.title ?? 'API Documentation';
 
       kori.get(uiPath, {
-        handler: (ctx) => {
+        handler: (ctx: any) => {
           const documentPath = ctx.env.openapi?.documentPath;
           if (!documentPath) {
             throw new Error('openApiPlugin must be registered before scalarUiPlugin');

--- a/packages/kori/src/index.ts
+++ b/packages/kori/src/index.ts
@@ -47,7 +47,13 @@ export {
   type KoriSimpleLoggerOptions,
   wrapKoriLogger,
 } from './logging/index.js';
-export { defineKoriRawPlugin, isKoriPlugin, type KoriPlugin, type KoriPluginDefault } from './plugin/index.js';
+export {
+  defineKoriPlugin,
+  defineKoriSimplePlugin,
+  isKoriPlugin,
+  type KoriPlugin,
+  type KoriPluginDefault,
+} from './plugin/index.js';
 export {
   createRequestValidator,
   type InferRequestValidatorError,

--- a/packages/kori/src/plugin/index.ts
+++ b/packages/kori/src/plugin/index.ts
@@ -1,1 +1,7 @@
-export { defineKoriRawPlugin, isKoriPlugin, type KoriPlugin, type KoriPluginDefault } from './plugin.js';
+export {
+  defineKoriPlugin,
+  defineKoriSimplePlugin,
+  isKoriPlugin,
+  type KoriPlugin,
+  type KoriPluginDefault,
+} from './plugin.js';


### PR DESCRIPTION
Rename plugin definition functions (`defineKoriRawPlugin` to `defineKoriPlugin`, and `defineKoriPlugin` to `defineKoriSimplePlugin`) to clarify their roles and enhance `defineKoriSimplePlugin` with all Kori hooks.

This PR refines the plugin API based on usage feedback. `defineKoriPlugin` (formerly `defineKoriRawPlugin`) is now the primary function for complex plugins that directly interact with the Kori instance (e.g., adding routes). `defineKoriSimplePlugin` (formerly `defineKoriPlugin`) is introduced as a more declarative, hook-based API for simpler plugins that extend context or perform side effects, now supporting all six Kori lifecycle and handler hooks for comprehensive functionality. This provides a clearer and more intuitive distinction for plugin developers.