### PR TITLE
Add Cursor rules and clean up guidelines

### DIFF
--- a/.cursor/rules/ai-assistant.mdc
+++ b/.cursor/rules/ai-assistant.mdc
@@ -1,0 +1,22 @@
+---
+description: 'AI assistant guidelines for Kori framework development'
+globs: []
+alwaysApply: true
+---
+
+# Guidelines for AI Assistant
+
+1.  **Strict Separation of Proposal and Execution**:
+
+    - Always present code changes as a "proposal" first. Do not execute any file modifications until I give explicit approval (e.g., "yes," "please proceed"). This is the most important rule.
+
+2.  **Prioritize Developer Experience (DX)**:
+
+    - When proposing API designs or code changes, always consider "How will a developer using this feel?" Prioritize ease of use, simplicity, and intuitiveness.
+
+3.  **Pursue Readable Code**:
+
+    - If logic becomes complex or nesting gets deep, proactively suggest refactoring, such as extracting functions or applying the early return pattern.
+
+4.  **Allow Breaking Changes for Better Design**:
+    - Prioritize cleaner code, better architecture, and improved DX over maintaining backward compatibility. Do not hesitate to propose breaking changes if they lead to a better design.

--- a/.cursor/rules/coding.mdc
+++ b/.cursor/rules/coding.mdc
@@ -1,33 +1,40 @@
 ---
-description: 
-globs: 
-alwaysApply: false
+description: 'Kori framework TypeScript coding standards and conventions'
+globs: ['**/*.ts', '**/*.js', '**/*.tsx', '**/*.jsx']
+alwaysApply: true
 ---
+
 # Coding Rules
 
 ## Imports
+
 - Always use `type` modifier for type imports
 - Always include `.js` extension in import paths for ESM compatibility
 
 ## Function Declarations
+
 - Use function declarations for framework public APIs
 - Avoid arrow functions for public APIs
 
 ## Type Definitions
+
 - Prefer `type` over `interface`
 - Use `never` as default type parameter instead of `{}`
 
 ## File Organization
+
 - Keep related types together
 - Export public APIs at the end of the file
 - Folder names and file names should use the singular form.
 
 ## Terminology
+
 - Use "Plugin" instead of "Middleware"
 - Avoid "use" for adding plugins
 - Avoid middleware-related terms in APIs and documentation
 
 ## Naming Conventions
+
 - Use camelCase for function names, variable names, and property names
 - For abbreviations in camelCase, treat them as regular words:
   - `API` → `Api` (e.g., `openApiPlugin`, `zodOpenApiPlugin`)
@@ -38,37 +45,19 @@ alwaysApply: false
 - Avoid inconsistent casing like `scalarUIPlugin` or `openAPIPlugin`
 
 ## Module System
+
 - Use ESM (ECMAScript Modules) format
 - Include file extensions in import paths
 
 ## Architecture
+
 - Prefer functions over classes
 - Use composition over inheritance
 - Avoid using 'this' keyword
 
 ## Character Encoding
+
 - Source code files (.ts, .js, .tsx, .jsx) must contain only ASCII characters
 - Non-ASCII characters (emojis, Japanese, etc.) are prohibited in source code
 - Documentation files (.md, .mdc, README) may use non-ASCII characters freely
 - This ensures encoding compatibility and tool interoperability
-
-## Commit Messages
-
-- For commit messages, keep them super short and concise. Just a couple of sentences max.
-- Use only ASCII characters in commit messages (no emojis, Japanese, etc.)
-- Write commit messages in English for international collaboration
-
-# Guidelines for AI Assistant
-
-1.  **Strict Separation of Proposal and Execution**:
-    *   Always present code changes as a "proposal" first. Do not execute any file modifications until I give explicit approval (e.g., "yes," "please proceed"). This is the most important rule.
-
-2.  **Prioritize Developer Experience (DX)**:
-    *   When proposing API designs or code changes, always consider "How will a developer using this feel?" Prioritize ease of use, simplicity, and intuitiveness.
-
-3.  **Pursue Readable Code**:
-    *   If logic becomes complex or nesting gets deep, proactively suggest refactoring, such as extracting functions or applying the early return pattern.
-
-4.  **Allow Breaking Changes for Better Design**:
-    *   Prioritize cleaner code, better architecture, and improved DX over maintaining backward compatibility. Do not hesitate to propose breaking changes if they lead to a better design.
-

--- a/.cursor/rules/git.mdc
+++ b/.cursor/rules/git.mdc
@@ -1,0 +1,17 @@
+---
+description: 'Git workflow guidelines for Kori framework development'
+globs: []
+alwaysApply: true
+---
+
+# Git Rules
+
+## Commit Messages
+
+- For commit messages, keep them super short and concise. Just a couple of sentences max.
+- Use only ASCII characters in commit messages (no emojis, Japanese, etc.)
+- Write commit messages in English for international collaboration
+
+## Pull Requests
+
+- Write titles and descriptions in English for international collaboration

--- a/packages/kori-body-limit-plugin/src/body-limit-plugin.ts
+++ b/packages/kori-body-limit-plugin/src/body-limit-plugin.ts
@@ -185,7 +185,9 @@ export function bodyLimitPlugin<Env extends KoriEnvironment, Req extends KoriReq
             contentLength,
             maxSize,
             userAgent: req.headers['user-agent'],
-            remoteAddress: req.headers['x-forwarded-for'] ?? req.headers['x-real-ip'],
+            remoteAddress: req.headers['x-forwarded-for']?.trim()
+              ? req.headers['x-forwarded-for']
+              : req.headers['x-real-ip'],
           });
 
           // Use custom error handler if provided

--- a/packages/kori-body-limit-plugin/src/body-limit-plugin.ts
+++ b/packages/kori-body-limit-plugin/src/body-limit-plugin.ts
@@ -185,7 +185,7 @@ export function bodyLimitPlugin<Env extends KoriEnvironment, Req extends KoriReq
             contentLength,
             maxSize,
             userAgent: req.headers['user-agent'],
-            remoteAddress: req.headers['x-forwarded-for'] || req.headers['x-real-ip'],
+            remoteAddress: req.headers['x-forwarded-for'] ?? req.headers['x-real-ip'],
           });
 
           // Use custom error handler if provided

--- a/packages/kori-body-limit-plugin/src/body-limit-plugin.ts
+++ b/packages/kori-body-limit-plugin/src/body-limit-plugin.ts
@@ -179,15 +179,15 @@ export function bodyLimitPlugin<Env extends KoriEnvironment, Req extends KoriReq
         const contentLength = parseInt(contentLengthHeader, 10);
 
         if (contentLength > maxSize) {
+          const xForwardedFor = req.headers['x-forwarded-for']?.trim();
           requestLog.warn('Request body size exceeds limit', {
             path: req.url.pathname,
             method: req.method,
             contentLength,
             maxSize,
             userAgent: req.headers['user-agent'],
-            remoteAddress: req.headers['x-forwarded-for']?.trim()
-              ? req.headers['x-forwarded-for']
-              : req.headers['x-real-ip'],
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+            remoteAddress: xForwardedFor || req.headers['x-real-ip'],
           });
 
           // Use custom error handler if provided


### PR DESCRIPTION
- Add structured Cursor rules for Kori framework development
- Split rules into 3 categories: AI assistant, coding standards, and git workflow
- Move guidelines from guidelines/main.mdc to .cursor/rules/
- Update descriptions to be Kori framework specific
- Clean up repository structure