### PR TITLE
fix: align plugin versions with package.json versions

### DIFF
--- a/packages/kori-body-limit-plugin/src/body-limit-plugin.ts
+++ b/packages/kori-body-limit-plugin/src/body-limit-plugin.ts
@@ -7,6 +7,8 @@ import {
   HttpStatus,
 } from 'kori';
 
+import { PLUGIN_VERSION } from './version.js';
+
 export type BodyLimitOptions = {
   /** Maximum request body size in bytes (default: 1MB) */
   maxSize?: number;
@@ -116,7 +118,7 @@ export function bodyLimitPlugin<Env extends KoriEnvironment, Req extends KoriReq
 
   return defineKoriPlugin({
     name: PLUGIN_NAME,
-    version: '1.0.0',
+    version: PLUGIN_VERSION,
     apply: (kori) => {
       // Instance-level logger for plugin initialization
       const log = kori.log.child(LOGGER_NAME);

--- a/packages/kori-body-limit-plugin/src/version.ts
+++ b/packages/kori-body-limit-plugin/src/version.ts
@@ -1,0 +1,1 @@
+export const PLUGIN_VERSION = '0.0.1';

--- a/packages/kori-openapi-plugin/src/openapi-plugin.ts
+++ b/packages/kori-openapi-plugin/src/openapi-plugin.ts
@@ -16,6 +16,7 @@ import {
 } from 'openapi3-ts/oas31';
 
 import { createRouteCollector, type ConversionContext, type SchemaConverter } from './route-collector.js';
+import { PLUGIN_VERSION } from './version.js';
 
 export const OpenApiMetaSymbol = Symbol('openapi-meta');
 
@@ -98,7 +99,7 @@ export function openApiPlugin<Env extends KoriEnvironment, Req extends KoriReque
 
   return defineKoriPlugin({
     name: 'openapi',
-    version: '1.0.0',
+    version: PLUGIN_VERSION,
     apply: (kori) => {
       // Add OpenAPI document endpoint
       kori.get(documentPath, {

--- a/packages/kori-openapi-plugin/src/version.ts
+++ b/packages/kori-openapi-plugin/src/version.ts
@@ -1,0 +1,1 @@
+export const PLUGIN_VERSION = '0.0.1';


### PR DESCRIPTION
## Summary
Align plugin versions with their package.json versions.

## Changes
- Add version.ts files for body-limit and openapi plugins
- Replace hardcoded versions (1.0.0) with imports from version.ts
- Plugin versions now match package.json versions (0.0.1)

## Benefits
- Platform-independent approach (works with Node.js, Deno, Bun)
- Easier version management (only need to update version.ts files)
- Centralized version control