### PR TITLE
feat: Add 415 Unsupported Media Type error handling with pre-validation system

### DIFF
--- a/packages/kori/src/context/response.ts
+++ b/packages/kori/src/context/response.ts
@@ -55,6 +55,7 @@ export type KoriResponse = {
   forbidden(options?: ErrorResponseOptions): KoriResponse;
   notFound(options?: ErrorResponseOptions): KoriResponse;
   methodNotAllowed(options?: ErrorResponseOptions): KoriResponse;
+  unsupportedMediaType(options?: ErrorResponseOptions): KoriResponse;
   timeout(options?: ErrorResponseOptions): KoriResponse;
   internalError(options?: ErrorResponseOptions): KoriResponse;
 
@@ -84,6 +85,7 @@ type ErrorType =
   | 'FORBIDDEN'
   | 'NOT_FOUND'
   | 'METHOD_NOT_ALLOWED'
+  | 'UNSUPPORTED_MEDIA_TYPE'
   | 'TIMEOUT'
   | 'INTERNAL_SERVER_ERROR';
 
@@ -246,6 +248,27 @@ export function createKoriResponse(): KoriResponse {
           type: 'json',
           value: createErrorResponseBodyJson({
             errorType: 'METHOD_NOT_ALLOWED',
+            message,
+            details: options.details,
+          }),
+        };
+      }
+      return self;
+    },
+
+    unsupportedMediaType: function (options: ErrorResponseOptions = {}) {
+      internalState.status = HttpStatus.UNSUPPORTED_MEDIA_TYPE;
+      const message = options.message ?? 'Unsupported Media Type';
+      if (options.type === 'text') {
+        internalState.body = {
+          type: 'text',
+          value: message,
+        };
+      } else {
+        internalState.body = {
+          type: 'json',
+          value: createErrorResponseBodyJson({
+            errorType: 'UNSUPPORTED_MEDIA_TYPE',
             message,
             details: options.details,
           }),

--- a/packages/kori/src/index.ts
+++ b/packages/kori/src/index.ts
@@ -28,10 +28,12 @@ export {
   type Kori,
   type KoriAddRoute,
   type KoriHandler,
+  type KoriInstancePreRequestValidationErrorHandler,
   type KoriInstanceRequestValidationErrorHandler,
   type KoriInstanceResponseValidationErrorHandler,
   type KoriRouteDefinition,
   type KoriRoutePluginMetadata,
+  type KoriRoutePreRequestValidationErrorHandler,
   type KoriRouteRequestValidationErrorHandler,
   type KoriRouteResponseValidationErrorHandler,
 } from './kori/index.js';
@@ -56,6 +58,8 @@ export {
   type KoriRequestValidatorDefault,
   type KoriRequestValidatorError,
   type KoriRequestValidatorErrorDefault,
+  type PreValidationError,
+  type RequestValidationError,
   type WithValidatedRequest,
 } from './request-validation/index.js';
 export {

--- a/packages/kori/src/kori/index.ts
+++ b/packages/kori/src/kori/index.ts
@@ -4,9 +4,11 @@ export {
   type HttpMethod,
   type KoriAddRoute,
   type KoriHandler,
+  type KoriInstancePreRequestValidationErrorHandler,
   type KoriInstanceRequestValidationErrorHandler,
   type KoriInstanceResponseValidationErrorHandler,
   type KoriRoutePluginMetadata,
+  type KoriRoutePreRequestValidationErrorHandler,
   type KoriRouteRequestValidationErrorHandler,
   type KoriRouteResponseValidationErrorHandler,
 } from './route.js';

--- a/packages/kori/src/kori/kori-creator.ts
+++ b/packages/kori/src/kori/kori-creator.ts
@@ -8,6 +8,7 @@ import { createHonoRouter, type KoriRouter } from '../router/index.js';
 import { createKoriInternal, type KoriInternalShared } from './kori-internal.js';
 import { type Kori } from './kori.js';
 import {
+  type KoriInstancePreRequestValidationErrorHandler,
   type KoriInstanceRequestValidationErrorHandler,
   type KoriInstanceResponseValidationErrorHandler,
 } from './route.js';
@@ -18,13 +19,18 @@ type CreateKoriOptions<
 > = {
   requestValidator?: RequestValidator;
   responseValidator?: ResponseValidator;
-  instanceRequestValidationErrorHandler?: KoriInstanceRequestValidationErrorHandler<
+  onPreRequestValidationError?: KoriInstancePreRequestValidationErrorHandler<
+    KoriEnvironment,
+    KoriRequest,
+    KoriResponse
+  >;
+  onRequestValidationError?: KoriInstanceRequestValidationErrorHandler<
     KoriEnvironment,
     KoriRequest,
     KoriResponse,
     RequestValidator
   >;
-  instanceResponseValidationErrorHandler?: KoriInstanceResponseValidationErrorHandler<
+  onResponseValidationError?: KoriInstanceResponseValidationErrorHandler<
     KoriEnvironment,
     KoriRequest,
     KoriResponse,
@@ -57,8 +63,9 @@ export function createKori<
     shared,
     requestValidator: options?.requestValidator,
     responseValidator: options?.responseValidator,
-    instanceRequestValidationErrorHandler: options?.instanceRequestValidationErrorHandler,
-    instanceResponseValidationErrorHandler: options?.instanceResponseValidationErrorHandler,
+    onPreRequestValidationError: options?.onPreRequestValidationError,
+    onRequestValidationError: options?.onRequestValidationError,
+    onResponseValidationError: options?.onResponseValidationError,
   });
 
   shared.root = root;

--- a/packages/kori/src/kori/kori-internal.ts
+++ b/packages/kori/src/kori/kori-internal.ts
@@ -23,6 +23,7 @@ import { type RequestProviderCompatibility, type ResponseProviderCompatibility }
 import {
   type HttpMethod,
   type KoriHandler,
+  type KoriInstancePreRequestValidationErrorHandler,
   type KoriInstanceRequestValidationErrorHandler,
   type KoriInstanceResponseValidationErrorHandler,
   type KoriRoutePluginMetadata,
@@ -70,8 +71,9 @@ export function createKoriInternal<
   shared,
   requestValidator,
   responseValidator,
-  instanceRequestValidationErrorHandler,
-  instanceResponseValidationErrorHandler,
+  onPreRequestValidationError,
+  onRequestValidationError,
+  onResponseValidationError,
   prefix = '',
   parentHandlerHooks = {
     requestHooks: [],
@@ -83,8 +85,9 @@ export function createKoriInternal<
   shared: KoriInternalShared;
   requestValidator?: RequestValidator;
   responseValidator?: ResponseValidator;
-  instanceRequestValidationErrorHandler?: KoriInstanceRequestValidationErrorHandler<Env, Req, Res, RequestValidator>;
-  instanceResponseValidationErrorHandler?: KoriInstanceResponseValidationErrorHandler<Env, Req, Res, ResponseValidator>;
+  onPreRequestValidationError?: KoriInstancePreRequestValidationErrorHandler<Env, Req, Res>;
+  onRequestValidationError?: KoriInstanceRequestValidationErrorHandler<Env, Req, Res, RequestValidator>;
+  onResponseValidationError?: KoriInstanceResponseValidationErrorHandler<Env, Req, Res, ResponseValidator>;
   prefix?: string;
   parentHandlerHooks?: {
     requestHooks: KoriOnRequestHookAny[];
@@ -96,8 +99,9 @@ export function createKoriInternal<
   const _shared = shared;
   const _requestValidator = requestValidator;
   const _responseValidator = responseValidator;
-  const _instanceRequestValidationErrorHandler = instanceRequestValidationErrorHandler;
-  const _instanceResponseValidationErrorHandler = instanceResponseValidationErrorHandler;
+  const _onPreRequestValidationError = onPreRequestValidationError;
+  const _onRequestValidationError = onRequestValidationError;
+  const _onResponseValidationError = onResponseValidationError;
   const _prefix = prefix;
 
   const _children: KoriInternalAny[] = [];
@@ -177,8 +181,9 @@ export function createKoriInternal<
         shared: _shared,
         requestValidator: _requestValidator,
         responseValidator: _responseValidator,
-        instanceRequestValidationErrorHandler: _instanceRequestValidationErrorHandler,
-        instanceResponseValidationErrorHandler: _instanceResponseValidationErrorHandler,
+        onPreRequestValidationError: _onPreRequestValidationError,
+        onRequestValidationError: _onRequestValidationError,
+        onResponseValidationError: _onResponseValidationError,
         prefix: `${_prefix}${childOptions.prefix ?? ''}`,
         parentHandlerHooks: {
           requestHooks: _requestHooks,
@@ -248,8 +253,9 @@ export function createKoriInternal<
         {
           requestValidator: _requestValidator,
           responseValidator: _responseValidator,
-          instanceRequestValidationErrorHandler: _instanceRequestValidationErrorHandler,
-          instanceResponseValidationErrorHandler: _instanceResponseValidationErrorHandler,
+          onPreRequestValidationError: _onPreRequestValidationError,
+          onRequestValidationError: _onRequestValidationError,
+          onResponseValidationError: _onResponseValidationError,
           requestHooks: _requestHooks,
           responseHooks: _responseHooks,
           errorHooks: _errorHooks,

--- a/packages/kori/src/kori/route.ts
+++ b/packages/kori/src/kori/route.ts
@@ -8,6 +8,7 @@ import {
   type WithValidatedRequest,
   type InferRequestValidatorError,
   type KoriRequestValidatorDefault,
+  type PreValidationError,
 } from '../request-validation/index.js';
 import { type InferResponseValidationError, type KoriResponseValidatorDefault } from '../response-validation/index.js';
 import { type WithPathParams } from '../router/index.js';
@@ -37,6 +38,22 @@ export type KoriHandler<
 > = (
   ctx: KoriHandlerContext<Env, WithValidatedRequest<WithPathParams<Req, Path>, RequestValidator, RequestSchema>, Res>,
 ) => MaybePromise<KoriResponse>;
+
+export type KoriInstancePreRequestValidationErrorHandler<
+  Env extends KoriEnvironment,
+  Req extends KoriRequest,
+  Res extends KoriResponse,
+> = (ctx: KoriHandlerContext<Env, Req, Res>, err: PreValidationError) => MaybePromise<KoriResponse | void>;
+
+export type KoriRoutePreRequestValidationErrorHandler<
+  Env extends KoriEnvironment,
+  Req extends KoriRequest,
+  Res extends KoriResponse,
+  Path extends string,
+> = (
+  ctx: KoriHandlerContext<Env, WithPathParams<Req, Path>, Res>,
+  err: PreValidationError,
+) => MaybePromise<KoriResponse | void>;
 
 export type KoriInstanceRequestValidationErrorHandler<
   Env extends KoriEnvironment,

--- a/packages/kori/src/request-validation/index.ts
+++ b/packages/kori/src/request-validation/index.ts
@@ -1,3 +1,5 @@
+export { type PreValidationError } from './pre-validation-error.js';
+export { type RequestValidationError } from './request-validation-error.js';
 export { resolveRequestValidationFunction } from './request-validation-resolver.js';
 export {
   createRequestValidator,

--- a/packages/kori/src/request-validation/pre-validation-error.ts
+++ b/packages/kori/src/request-validation/pre-validation-error.ts
@@ -1,0 +1,12 @@
+export type PreValidationError =
+  | {
+      type: 'UNSUPPORTED_MEDIA_TYPE';
+      message: string;
+      supportedTypes: string[];
+      requestedType: string | undefined;
+    }
+  | {
+      type: 'INVALID_JSON';
+      message: string;
+      cause: unknown;
+    };

--- a/packages/kori/src/request-validation/request-validation-error.ts
+++ b/packages/kori/src/request-validation/request-validation-error.ts
@@ -1,0 +1,11 @@
+import { type PreValidationError } from './pre-validation-error.js';
+
+export type RequestValidationError<TValidatorError = unknown> =
+  | {
+      stage: 'pre-validation';
+      error: PreValidationError;
+    }
+  | {
+      stage: 'validation';
+      error: TValidatorError;
+    };


### PR DESCRIPTION
## 🎯 Overview

Implements comprehensive error handling for 415 Unsupported Media Type and introduces a new pre-validation system that separates Content-Type/JSON parsing errors from schema validation errors.

## 🚀 Features

### New API
- `onPreRequestValidationError` - Handles Content-Type and JSON parsing errors
- `onRequestValidationError` - Handles schema validation errors (renamed from `instanceRequestValidationErrorHandler`)
- `onResponseValidationError` - Handles response validation errors
- `KoriResponse.unsupportedMediaType()` - 415 error response method

### Error Handling Flow
1. **Pre-validation** (automatic): Content-Type check → JSON parsing
2. **Validation** (customizable): Schema validation

## 📋 Changes

### Core Changes
- ✅ Added `PreValidationError` and `RequestValidationError` types
- ✅ Updated request validation resolver with pre-validation logic
- ✅ Modified route handler factory for multi-stage error handling
- ✅ Added `unsupportedMediaType()` method to `KoriResponse`

### API Changes
- ✅ Renamed `instanceRequestValidationErrorHandler` → `onRequestValidationError`
- ✅ Added `onPreRequestValidationError` handler
- ✅ Updated `createKori()` options with new handlers

### Example Usage
```typescript
const app = createKori({
  requestValidator: createKoriZodRequestValidator(),
  
  // Pre-validation errors (415, JSON parse) - Auto-handled
  onPreRequestValidationError: (ctx, err) => {
    switch (err.type) {
      case 'UNSUPPORTED_MEDIA_TYPE':
        return ctx.res.unsupportedMediaType({
          message: `Supported: ${err.supportedTypes.join(', ')}`,
          details: { supported: err.supportedTypes, requested: err.requestedType }
        });
      case 'INVALID_JSON':
        return ctx.res.badRequest({ message: 'Invalid JSON' });
    }
  },
  
  // Validation errors (schema violations)
  onRequestValidationError: (ctx, err) => {
    return ctx.res.badRequest({ message: 'Validation failed', details: err });
  },
});
```

## 🔄 Breaking Changes

⚠️ **API Changes** (as discussed, backward compatibility was not a concern):
- `instanceRequestValidationErrorHandler` → `onRequestValidationError`
- `instanceResponseValidationErrorHandler` → `onResponseValidationError`

## 🧪 Testing

Updated examples in `kori-example/src/usage.ts` demonstrate:
- ❌ `Content-Type: text/plain` → **415 Unsupported Media Type**
- ❌ Invalid JSON → **400 Bad Request** 
- ❌ Schema violations → **400 Bad Request** (customizable)
- ✅ Valid requests → Normal processing

## 🎯 Benefits

1. **Type Safety**: Discriminated unions ensure compile-time error checking
2. **Automatic Handling**: 415/400 errors work out of the box
3. **Flexible Customization**: Override default behavior as needed
4. **Clear Separation**: Pre-validation vs validation errors are distinct
5. **Better DX**: Developers get appropriate error messages automatically