### PR TITLE
refactor: change request validation error from array to object structure

### DIFF
--- a/packages/kori/src/index.ts
+++ b/packages/kori/src/index.ts
@@ -52,6 +52,8 @@ export {
   createRequestValidator,
   type InferRequestValidatorError,
   type InferRequestValidatorSchemaProvider,
+  type KoriBodyValidationError,
+  type KoriFieldValidationError,
   type KoriRequestValidationError,
   type KoriRequestValidator,
   type KoriRequestValidatorDefault,

--- a/packages/kori/src/request-validation/index.ts
+++ b/packages/kori/src/request-validation/index.ts
@@ -1,4 +1,4 @@
-export { type KoriRequestFieldError, type KoriRequestValidationError } from './request-validation-error.js';
+export { type KoriRequestValidationError } from './request-validation-error.js';
 export { resolveRequestValidationFunction } from './request-validation-resolver.js';
 export {
   createRequestValidator,

--- a/packages/kori/src/request-validation/index.ts
+++ b/packages/kori/src/request-validation/index.ts
@@ -1,4 +1,8 @@
-export { type KoriRequestValidationError } from './request-validation-error.js';
+export {
+  type KoriBodyValidationError,
+  type KoriFieldValidationError,
+  type KoriRequestValidationError,
+} from './request-validation-error.js';
 export { resolveRequestValidationFunction } from './request-validation-resolver.js';
 export {
   createRequestValidator,
@@ -8,5 +12,6 @@ export {
   type KoriRequestValidatorDefault,
   type KoriRequestValidatorError,
   type KoriRequestValidatorErrorDefault,
+  type KoriRequestValidatorMethods,
 } from './request-validator.js';
 export { type WithValidatedRequest } from './validated-request.js';

--- a/packages/kori/src/request-validation/request-validation-error.ts
+++ b/packages/kori/src/request-validation/request-validation-error.ts
@@ -1,28 +1,34 @@
-// Request validation error types (field-first discriminated-union)
+// Request validation error types (field-based object structure)
 
-export type KoriRequestField = 'params' | 'queries' | 'headers' | 'body';
-
-export type KoriBodyPreValidationErrorKind = 'UNSUPPORTED_MEDIA_TYPE' | 'INVALID_JSON';
-
-export type KoriRequestFieldError<TValidatorError = unknown> =
-  | {
-      // Pre-validation error produced during body parsing
-      field: 'body';
-      stage: 'pre-validation';
-      type: KoriBodyPreValidationErrorKind;
-      message: string;
-      // For UNSUPPORTED_MEDIA_TYPE
-      supportedTypes?: string[];
-      requestedType?: string;
-      // For INVALID_JSON
-      cause?: unknown;
-    }
-  | {
-      // Schema validation error for any field
-      field: KoriRequestField;
-      stage: 'validation';
-      error: TValidatorError;
-    };
-
-// The handler receives an array of field errors
-export type KoriRequestValidationError<TValidatorError = unknown> = KoriRequestFieldError<TValidatorError>[];
+export type KoriRequestValidationError<TValidatorError = unknown> = {
+  params?: {
+    stage: 'validation';
+    error: TValidatorError;
+  };
+  queries?: {
+    stage: 'validation';
+    error: TValidatorError;
+  };
+  headers?: {
+    stage: 'validation';
+    error: TValidatorError;
+  };
+  body?:
+    | {
+        stage: 'validation';
+        error: TValidatorError;
+      }
+    | {
+        stage: 'pre-validation';
+        type: 'UNSUPPORTED_MEDIA_TYPE';
+        message: string;
+        supportedTypes: string[];
+        requestedType?: string;
+      }
+    | {
+        stage: 'pre-validation';
+        type: 'INVALID_JSON';
+        message: string;
+        cause?: unknown;
+      };
+};

--- a/packages/kori/src/request-validation/request-validation-error.ts
+++ b/packages/kori/src/request-validation/request-validation-error.ts
@@ -1,34 +1,29 @@
 // Request validation error types (field-based object structure)
 
+export type KoriFieldValidationError<TValidatorError> = {
+  stage: 'validation';
+  error: TValidatorError;
+};
+
+export type KoriBodyValidationError<TValidatorError> =
+  | KoriFieldValidationError<TValidatorError>
+  | {
+      stage: 'pre-validation';
+      type: 'UNSUPPORTED_MEDIA_TYPE';
+      message: string;
+      supportedTypes: string[];
+      requestedType?: string;
+    }
+  | {
+      stage: 'pre-validation';
+      type: 'INVALID_JSON';
+      message: string;
+      cause?: unknown;
+    };
+
 export type KoriRequestValidationError<TValidatorError = unknown> = {
-  params?: {
-    stage: 'validation';
-    error: TValidatorError;
-  };
-  queries?: {
-    stage: 'validation';
-    error: TValidatorError;
-  };
-  headers?: {
-    stage: 'validation';
-    error: TValidatorError;
-  };
-  body?:
-    | {
-        stage: 'validation';
-        error: TValidatorError;
-      }
-    | {
-        stage: 'pre-validation';
-        type: 'UNSUPPORTED_MEDIA_TYPE';
-        message: string;
-        supportedTypes: string[];
-        requestedType?: string;
-      }
-    | {
-        stage: 'pre-validation';
-        type: 'INVALID_JSON';
-        message: string;
-        cause?: unknown;
-      };
+  params?: KoriFieldValidationError<TValidatorError>;
+  queries?: KoriFieldValidationError<TValidatorError>;
+  headers?: KoriFieldValidationError<TValidatorError>;
+  body?: KoriBodyValidationError<TValidatorError>;
 };

--- a/packages/kori/src/request-validation/request-validation-resolver.ts
+++ b/packages/kori/src/request-validation/request-validation-resolver.ts
@@ -2,42 +2,12 @@ import { type KoriRequest } from '../context/index.js';
 import { type KoriRequestSchemaDefault, type KoriRequestSchemaContentDefault, isKoriSchema } from '../schema/index.js';
 import { ok, err, type KoriResult } from '../util/index.js';
 
-import { type KoriRequestValidationError } from './request-validation-error.js';
+import {
+  type KoriRequestValidationError,
+  type KoriFieldValidationError,
+  type KoriBodyValidationError,
+} from './request-validation-error.js';
 import { type KoriRequestValidatorDefault } from './request-validator.js';
-
-type ParamsValidationError<TValidatorError> = {
-  stage: 'validation';
-  error: TValidatorError;
-};
-
-type QueriesValidationError<TValidatorError> = {
-  stage: 'validation';
-  error: TValidatorError;
-};
-
-type HeadersValidationError<TValidatorError> = {
-  stage: 'validation';
-  error: TValidatorError;
-};
-
-type BodyValidationError<TValidatorError> =
-  | {
-      stage: 'validation';
-      error: TValidatorError;
-    }
-  | {
-      stage: 'pre-validation';
-      type: 'UNSUPPORTED_MEDIA_TYPE';
-      message: string;
-      supportedTypes: string[];
-      requestedType?: string;
-    }
-  | {
-      stage: 'pre-validation';
-      type: 'INVALID_JSON';
-      message: string;
-      cause?: unknown;
-    };
 
 async function validateRequestParams({
   validator,
@@ -47,7 +17,7 @@ async function validateRequestParams({
   validator: KoriRequestValidatorDefault;
   schema: KoriRequestSchemaDefault['params'];
   req: KoriRequest;
-}): Promise<KoriResult<unknown, ParamsValidationError<unknown>>> {
+}): Promise<KoriResult<unknown, KoriFieldValidationError<unknown>>> {
   if (!schema) {
     return ok(undefined);
   }
@@ -71,7 +41,7 @@ async function validateRequestQueries({
   validator: KoriRequestValidatorDefault;
   schema: KoriRequestSchemaDefault['queries'];
   req: KoriRequest;
-}): Promise<KoriResult<unknown, QueriesValidationError<unknown>>> {
+}): Promise<KoriResult<unknown, KoriFieldValidationError<unknown>>> {
   if (!schema) {
     return ok(undefined);
   }
@@ -95,7 +65,7 @@ async function validateRequestHeaders({
   validator: KoriRequestValidatorDefault;
   schema: KoriRequestSchemaDefault['headers'];
   req: KoriRequest;
-}): Promise<KoriResult<unknown, HeadersValidationError<unknown>>> {
+}): Promise<KoriResult<unknown, KoriFieldValidationError<unknown>>> {
   if (!schema) {
     return ok(undefined);
   }
@@ -119,7 +89,7 @@ async function validateRequestBody({
   validator: KoriRequestValidatorDefault;
   schema: KoriRequestSchemaDefault['body'];
   req: KoriRequest;
-}): Promise<KoriResult<unknown, BodyValidationError<unknown>>> {
+}): Promise<KoriResult<unknown, KoriBodyValidationError<unknown>>> {
   if (!schema) {
     return ok(undefined);
   }

--- a/packages/kori/src/request-validation/request-validation-resolver.ts
+++ b/packages/kori/src/request-validation/request-validation-resolver.ts
@@ -2,8 +2,42 @@ import { type KoriRequest } from '../context/index.js';
 import { type KoriRequestSchemaDefault, type KoriRequestSchemaContentDefault, isKoriSchema } from '../schema/index.js';
 import { ok, err, type KoriResult } from '../util/index.js';
 
-import { type KoriRequestFieldError, type KoriRequestValidationError } from './request-validation-error.js';
+import { type KoriRequestValidationError } from './request-validation-error.js';
 import { type KoriRequestValidatorDefault } from './request-validator.js';
+
+type ParamsValidationError<TValidatorError> = {
+  stage: 'validation';
+  error: TValidatorError;
+};
+
+type QueriesValidationError<TValidatorError> = {
+  stage: 'validation';
+  error: TValidatorError;
+};
+
+type HeadersValidationError<TValidatorError> = {
+  stage: 'validation';
+  error: TValidatorError;
+};
+
+type BodyValidationError<TValidatorError> =
+  | {
+      stage: 'validation';
+      error: TValidatorError;
+    }
+  | {
+      stage: 'pre-validation';
+      type: 'UNSUPPORTED_MEDIA_TYPE';
+      message: string;
+      supportedTypes: string[];
+      requestedType?: string;
+    }
+  | {
+      stage: 'pre-validation';
+      type: 'INVALID_JSON';
+      message: string;
+      cause?: unknown;
+    };
 
 async function validateRequestParams({
   validator,
@@ -13,7 +47,7 @@ async function validateRequestParams({
   validator: KoriRequestValidatorDefault;
   schema: KoriRequestSchemaDefault['params'];
   req: KoriRequest;
-}): Promise<KoriResult<unknown, KoriRequestFieldError>> {
+}): Promise<KoriResult<unknown, ParamsValidationError<unknown>>> {
   if (!schema) {
     return ok(undefined);
   }
@@ -24,7 +58,6 @@ async function validateRequestParams({
   }
 
   return err({
-    field: 'params',
     stage: 'validation',
     error: result.error,
   });
@@ -38,7 +71,7 @@ async function validateRequestQueries({
   validator: KoriRequestValidatorDefault;
   schema: KoriRequestSchemaDefault['queries'];
   req: KoriRequest;
-}): Promise<KoriResult<unknown, KoriRequestFieldError>> {
+}): Promise<KoriResult<unknown, QueriesValidationError<unknown>>> {
   if (!schema) {
     return ok(undefined);
   }
@@ -49,7 +82,6 @@ async function validateRequestQueries({
   }
 
   return err({
-    field: 'queries',
     stage: 'validation',
     error: result.error,
   });
@@ -63,7 +95,7 @@ async function validateRequestHeaders({
   validator: KoriRequestValidatorDefault;
   schema: KoriRequestSchemaDefault['headers'];
   req: KoriRequest;
-}): Promise<KoriResult<unknown, KoriRequestFieldError>> {
+}): Promise<KoriResult<unknown, HeadersValidationError<unknown>>> {
   if (!schema) {
     return ok(undefined);
   }
@@ -74,7 +106,6 @@ async function validateRequestHeaders({
   }
 
   return err({
-    field: 'headers',
     stage: 'validation',
     error: result.error,
   });
@@ -88,7 +119,7 @@ async function validateRequestBody({
   validator: KoriRequestValidatorDefault;
   schema: KoriRequestSchemaDefault['body'];
   req: KoriRequest;
-}): Promise<KoriResult<unknown, KoriRequestFieldError>> {
+}): Promise<KoriResult<unknown, BodyValidationError<unknown>>> {
   if (!schema) {
     return ok(undefined);
   }
@@ -102,13 +133,11 @@ async function validateRequestBody({
       }
 
       return err({
-        field: 'body',
         stage: 'validation',
         error: result.error,
       });
     } catch (error) {
       return err({
-        field: 'body',
         stage: 'pre-validation',
         type: 'INVALID_JSON',
         message: 'Failed to parse request body as JSON',
@@ -122,7 +151,6 @@ async function validateRequestBody({
 
   if (!contentType || !(contentType in content)) {
     return err({
-      field: 'body',
       stage: 'pre-validation',
       type: 'UNSUPPORTED_MEDIA_TYPE',
       message: 'Unsupported Media Type',
@@ -143,13 +171,11 @@ async function validateRequestBody({
     }
 
     return err({
-      field: 'body',
       stage: 'validation',
       error: result.error,
     });
   } catch (error) {
     return err({
-      field: 'body',
       stage: 'pre-validation',
       type: 'INVALID_JSON',
       message: `Failed to parse request body as ${contentType}`,
@@ -188,11 +214,11 @@ export function resolveRequestValidationFunction({
       });
     }
 
-    const errors: KoriRequestFieldError<unknown>[] = [];
-    if (!paramsResult.ok) errors.push(paramsResult.error);
-    if (!queriesResult.ok) errors.push(queriesResult.error);
-    if (!headersResult.ok) errors.push(headersResult.error);
-    if (!bodyResult.ok) errors.push(bodyResult.error);
+    const errors: KoriRequestValidationError<unknown> = {};
+    if (!paramsResult.ok) errors.params = paramsResult.error;
+    if (!queriesResult.ok) errors.queries = queriesResult.error;
+    if (!headersResult.ok) errors.headers = headersResult.error;
+    if (!bodyResult.ok) errors.body = bodyResult.error;
     return err(errors);
   };
 }

--- a/packages/kori/src/request-validation/request-validator.ts
+++ b/packages/kori/src/request-validation/request-validator.ts
@@ -1,7 +1,7 @@
 import { type InferSchemaOutput, type KoriSchemaDefault, type KoriSchemaProviderDefault } from '../schema/index.js';
 import { type KoriResult, type MaybePromise } from '../util/index.js';
 
-import { type KoriRequestFieldError } from './request-validation-error.js';
+import { type KoriRequestValidationError } from './request-validation-error.js';
 
 const ProviderProp = Symbol('schema-provider-prop');
 
@@ -58,5 +58,5 @@ export type KoriRequestValidatorErrorDefault = KoriRequestValidatorError<unknown
 
 export type InferRequestValidatorError<V extends KoriRequestValidatorDefault | undefined> =
   V extends KoriRequestValidator<infer _Provider, infer _Schema, infer ErrorType>
-    ? KoriRequestFieldError<ErrorType>[]
+    ? KoriRequestValidationError<ErrorType>
     : never;


### PR DESCRIPTION
## Summary

This PR refactors the request validation error structure from an array-based approach to an object-based approach with discriminated unions.

## Changes

- **Breaking Change**: KoriRequestValidationError is now an object with optional field properties instead of an array
- Remove legacy types: KoriRequestField, KoriBodyPreValidationErrorKind, KoriRequestFieldError
- Update validation resolver to build object instead of array
- Improve type safety with discriminated unions for body validation errors
- Enable direct field access for better developer experience

## Benefits

1. **Type Safety**: More precise type checking with discriminated unions
2. **Developer Experience**: Direct field access without array searching
3. **Performance**: No need for array traversal
4. **Cleaner API**: More intuitive error structure

## Breaking Change

This is a breaking change for any code that handles request validation errors. The migration is straightforward:

- Replace errors.find(e => e.field === fieldName) with errors.fieldName
- Update error handler implementations to use the new object structure