### PR TITLE
Add custom body parser support for plugin extensibility

### DIFF
--- a/packages/kori/src/request-validation/validate-request-body.ts
+++ b/packages/kori/src/request-validation/validate-request-body.ts
@@ -11,20 +11,6 @@ import { ok, err, type KoriResult } from '../util/index.js';
 import { type KoriBodyValidationError } from './request-validation-error.js';
 import { type KoriRequestValidatorDefault } from './request-validator.js';
 
-function parseRequestBody(req: KoriRequest, contentType: string): Promise<unknown> {
-  switch (contentType) {
-    case ContentType.APPLICATION_JSON:
-      return req.json();
-    case ContentType.APPLICATION_FORM_URLENCODED:
-    case ContentType.MULTIPART_FORM_DATA:
-      return req.formData();
-    case ContentType.APPLICATION_OCTET_STREAM:
-      return req.arrayBuffer();
-    default:
-      return req.text();
-  }
-}
-
 function getParseErrorInfo(contentType: string) {
   return {
     type: 'INVALID_BODY' as const,
@@ -67,7 +53,7 @@ async function parseRequestBodyWithContentType(
   contentType: string,
 ): Promise<KoriResult<unknown, KoriBodyValidationError<unknown>>> {
   try {
-    const body = await parseRequestBody(req, contentType);
+    const body = req.customBodyParser ? await req.customBodyParser() : await req.bodyParser();
     return ok(body);
   } catch (error) {
     const errorInfo = getParseErrorInfo(contentType);


### PR DESCRIPTION
This PR introduces custom body parser support to enable flexible content parsing through plugins.

## Key Features

### 🔧 Enhanced KoriRequest API

- **`fullContentType()`**: Returns complete Content-Type header including parameters (e.g., charset)
- **`bodyParser()`**: Default body parsing logic based on Content-Type
- **`customBodyParser?`**: Optional custom parser that can be set by plugins

### 🎯 Plugin Extensibility

- Plugins can extend body parsing for custom Content-Types
- Support for legacy encodings (e.g., Shift_JIS)
- Support for additional formats (e.g., YAML, TOML)
- Graceful fallback to default parser

## Technical Implementation

### API Design

```typescript
type KoriRequest = {
  // New methods
  fullContentType(): string | null; // "text/plain; charset=shift_jis"
  bodyParser(): Promise<unknown>; // Default parsing logic
  customBodyParser?: () => Promise<unknown>; // Plugin-settable custom parser

  // Existing methods
  contentType(): ContentTypeValue | undefined; // "text/plain"
  json(): Promise<unknown>;
  // ... etc
};
```

### Plugin Usage Example

```typescript
const yamlParserPlugin = defineKoriPlugin({
  name: 'yaml-parser',
  apply: (kori) => {
    return kori.onRequest((req, res, next) => {
      req.customBodyParser = async () => {
        const fullContentType = req.fullContentType() ?? 'application/json';

        if (fullContentType === 'application/yaml') {
          const text = await req.text();
          return parseYaml(text);
        }

        // Fallback to default parser
        return req.bodyParser();
      };
      return next(req, res);
    });
  },
});

const app = createKori()
  .use(yamlParserPlugin)
  .post('/api', async (req, res) => {
    // Body is automatically parsed using custom parser
  });
```

### SJIS Support Example

```typescript
const sjisParserPlugin = defineKoriPlugin({
  name: 'sjis-parser',
  apply: (kori) => {
    return kori.onRequest((req, res, next) => {
      req.customBodyParser = async () => {
        if (req.fullContentType()?.includes('charset=shift_jis')) {
          const buffer = await req.arrayBuffer();
          return new TextDecoder('shift_jis').decode(buffer);
        }
        return req.bodyParser();
      };
      return next(req, res);
    });
  },
});
```

## Benefits

✅ **Extensibility**: Easy to add support for new Content-Types via plugins  
✅ **Legacy Support**: Handle legacy encodings and formats  
✅ **Type Safety**: Custom parsers work seamlessly with existing validation  
✅ **Backward Compatibility**: Existing code continues to work unchanged  
✅ **Plugin Ecosystem**: Enables rich plugin ecosystem for different formats

## Files Changed

- `packages/kori/src/context/request.ts` - Added new methods to KoriRequest
- `packages/kori/src/request-validation/validate-request-body.ts` - Use custom parser when available

This enhancement maintains the existing simple API while enabling powerful extensibility for diverse content parsing needs.
