### PR TITLE
feat: Refactor request body validation and add wildcard support

### DIFF
--- a/packages/kori/src/request-validation/resolve-request-body-schema.ts
+++ b/packages/kori/src/request-validation/resolve-request-body-schema.ts
@@ -1,0 +1,72 @@
+import { type KoriRequest } from '../context/index.js';
+import { DEFAULT_CONTENT_TYPE } from '../http/index.js';
+import {
+  type KoriRequestSchemaDefault,
+  type KoriRequestSchemaContentDefault,
+  type KoriSchemaDefault,
+  isKoriSchema,
+} from '../schema/index.js';
+import { ok, err, type KoriResult } from '../util/index.js';
+
+import { type KoriBodyValidationError } from './request-validation-error.js';
+
+function findMatchingMediaType({
+  requestContentType,
+  contentSchema,
+}: {
+  requestContentType: string;
+  contentSchema: KoriRequestSchemaContentDefault;
+}): string | undefined {
+  // 1. Exact match
+  if (requestContentType in contentSchema) {
+    return requestContentType;
+  }
+
+  // 2. Subtype wildcard (e.g., application/*)
+  const [mainType] = requestContentType.split('/');
+  const subtypeWildcard = `${mainType}/*`;
+  if (subtypeWildcard in contentSchema) {
+    return subtypeWildcard;
+  }
+
+  // 3. Full wildcard (*/*)
+  if ('*/*' in contentSchema) {
+    return '*/*';
+  }
+
+  return undefined;
+}
+
+export function resolveRequestBodySchema({
+  req,
+  schema,
+}: {
+  req: KoriRequest;
+  schema: NonNullable<KoriRequestSchemaDefault['body']>;
+}): KoriResult<{ schema: KoriSchemaDefault; mediaType?: string }, KoriBodyValidationError<unknown>> {
+  if (isKoriSchema(schema)) {
+    return ok({ schema });
+  }
+
+  const requestContentType = req.contentType() ?? DEFAULT_CONTENT_TYPE;
+  const contentSchema = (schema.content ?? schema) as KoriRequestSchemaContentDefault;
+
+  const matchedMediaType = findMatchingMediaType({ contentSchema, requestContentType });
+  if (!matchedMediaType) {
+    return err({
+      stage: 'pre-validation',
+      type: 'UNSUPPORTED_MEDIA_TYPE',
+      message: 'Unsupported Media Type',
+      supportedTypes: Object.keys(contentSchema),
+      requestedType: requestContentType,
+    });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const mediaTypeSchema = contentSchema[matchedMediaType]!;
+  const targetSchema = isKoriSchema(mediaTypeSchema) ? mediaTypeSchema : mediaTypeSchema.schema;
+  return ok({
+    schema: targetSchema,
+    mediaType: matchedMediaType,
+  });
+}


### PR DESCRIPTION
This pull request introduces a more robust and extensible body parsing mechanism. Key improvements include wildcard support for media types in `resolveRequestBodySchema`, which now lives in its own file for better modularity and testability. The logic for returning the `mediaType` has been corrected to reflect the actual schema key used, rather than the raw `Content-Type` header.

### Key Changes:

- **Wildcard Support:** `resolveRequestBodySchema` now supports `*/*` and `application/*` wildcards, selecting the most specific matching schema.
- **Dedicated Schema Resolver:** The schema resolution logic has been moved to its own file, `resolve-request-body-schema.ts`.
- **Accurate Media Type Return:** The resolved `mediaType` now correctly returns the key from the schema definition (e.g., `application/*`) instead of the request's `Content-Type`.
- **Code Cleanup:** Removed the unnecessary `getParseErrorInfo` helper function.

These changes make the request validation logic more aligned with OpenAPI specifications, more robust, and easier to maintain and test.
