### PR TITLE
feat: Add typed HTTP header constants and methods

### DIFF
--- a/packages/kori/src/context/request.ts
+++ b/packages/kori/src/context/request.ts
@@ -1,4 +1,9 @@
-import { type ContentTypeValue, ContentType, DEFAULT_CONTENT_TYPE } from '../http/index.js';
+import {
+  type ContentTypeValue,
+  ContentType,
+  DEFAULT_CONTENT_TYPE,
+  type HttpRequestHeaderValue,
+} from '../http/index.js';
 import { type KoriLogger } from '../logging/index.js';
 
 const KoriRequestBrand = Symbol('kori-request');
@@ -16,6 +21,7 @@ export type KoriRequest<PathParams extends Record<string, string> = Record<strin
 
   contentType(): ContentTypeValue | undefined;
   fullContentType(): string | undefined;
+  getHeader(key: HttpRequestHeaderValue): string | undefined;
   parseBody(): Promise<unknown>;
   parseBodyDefault(): Promise<unknown>;
   parseBodyCustom?: () => Promise<unknown>;
@@ -85,6 +91,10 @@ export function createKoriRequest<PathParams extends Record<string, string>>({
     return rawRequest.headers.get('content-type')?.trim().toLowerCase();
   }
 
+  function getHeader(key: HttpRequestHeaderValue): string | undefined {
+    return koriRequest.headers[key.toLowerCase()];
+  }
+
   async function parseBody(): Promise<unknown> {
     if (isCustomParsing) return parseBodyDefault();
     if (koriRequest.parseBodyCustom) {
@@ -149,6 +159,7 @@ export function createKoriRequest<PathParams extends Record<string, string>>({
     },
     contentType,
     fullContentType,
+    getHeader,
     parseBody,
     parseBodyDefault,
     json,

--- a/packages/kori/src/context/response.ts
+++ b/packages/kori/src/context/response.ts
@@ -1,4 +1,4 @@
-import { HttpStatus, type HttpStatusCode } from '../http/index.js';
+import { HttpStatus, type HttpStatusCode, type HttpResponseHeaderValue } from '../http/index.js';
 
 const KoriResponseBrand = Symbol('kori-response');
 
@@ -39,9 +39,9 @@ export type KoriResponse = {
 
   status(statusCode: HttpStatusCode): KoriResponse;
 
-  setHeader(name: string, value: string): KoriResponse;
-  appendHeader(name: string, value: string): KoriResponse;
-  removeHeader(name: string): KoriResponse;
+  setHeader(key: HttpResponseHeaderValue, value: string): KoriResponse;
+  appendHeader(key: HttpResponseHeaderValue, value: string): KoriResponse;
+  removeHeader(key: HttpResponseHeaderValue): KoriResponse;
 
   json<T>(body: T): KoriResponse;
   text(body: string): KoriResponse;
@@ -110,18 +110,18 @@ export function createKoriResponse(): KoriResponse {
       return self;
     },
 
-    setHeader: function (name: string, value: string) {
-      internalState.headers.set(name, value);
+    setHeader: function (key: HttpResponseHeaderValue, value: string) {
+      internalState.headers.set(key, value);
       return self;
     },
 
-    appendHeader: function (name: string, value: string) {
-      internalState.headers.append(name, value);
+    appendHeader: function (key: HttpResponseHeaderValue, value: string) {
+      internalState.headers.append(key, value);
       return self;
     },
 
-    removeHeader: function (name: string) {
-      internalState.headers.delete(name);
+    removeHeader: function (key: HttpResponseHeaderValue) {
+      internalState.headers.delete(key);
       return self;
     },
 

--- a/packages/kori/src/http/headers.ts
+++ b/packages/kori/src/http/headers.ts
@@ -1,0 +1,43 @@
+/**
+ * HTTP Request Header constants
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers#request_headers
+ */
+export const HttpRequestHeader = {
+  ACCEPT: 'accept',
+  ACCEPT_CHARSET: 'accept-charset',
+  ACCEPT_ENCODING: 'accept-encoding',
+  ACCEPT_LANGUAGE: 'accept-language',
+  AUTHORIZATION: 'authorization',
+  CACHE_CONTROL: 'cache-control',
+  CONTENT_TYPE: 'content-type',
+  COOKIE: 'cookie',
+  FORWARDED: 'forwarded',
+  FROM: 'from',
+  HOST: 'host',
+  USER_AGENT: 'user-agent',
+  X_FORWARDED_FOR: 'x-forwarded-for',
+  X_FORWARDED_HOST: 'x-forwarded-host',
+  X_FORWARDED_PROTO: 'x-forwarded-proto',
+} as const;
+
+export type HttpRequestHeaderValue = (typeof HttpRequestHeader)[keyof typeof HttpRequestHeader] | (string & {});
+
+/**
+ * HTTP Response Header constants
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers#response_headers
+ */
+export const HttpResponseHeader = {
+  ACCESS_CONTROL_ALLOW_ORIGIN: 'access-control-allow-origin',
+  CONTENT_ENCODING: 'content-encoding',
+  CONTENT_TYPE: 'content-type',
+  ETAG: 'etag',
+  LOCATION: 'location',
+  SET_COOKIE: 'set-cookie',
+  STRICT_TRANSPORT_SECURITY: 'strict-transport-security',
+  VARY: 'vary',
+  WWW_AUTHENTICATE: 'www-authenticate',
+} as const;
+
+export type HttpResponseHeaderValue = (typeof HttpResponseHeader)[keyof typeof HttpResponseHeader] | (string & {});

--- a/packages/kori/src/http/index.ts
+++ b/packages/kori/src/http/index.ts
@@ -1,3 +1,9 @@
 export { ContentType, type ContentTypeValue, DEFAULT_CONTENT_TYPE } from './content-types.js';
+export {
+  HttpRequestHeader,
+  type HttpRequestHeaderValue,
+  HttpResponseHeader,
+  type HttpResponseHeaderValue,
+} from './headers.js';
 export { getMethodString } from './method.js';
 export { HttpStatus, type HttpStatusCode } from './status-codes.js';


### PR DESCRIPTION
This PR enhances developer experience and type safety by introducing typed constants for common HTTP headers.

### Key Features:

- **`HttpRequestHeader` and `HttpResponseHeader`:** New constant objects provide access to common request and response header names in a type-safe manner.
- **`req.getHeader()`:** A new method on `KoriRequest` that accepts `HttpRequestHeaderValue`, providing IDE autocompletion and preventing typos.
- **`res.setHeader()` and related methods:** The `KoriResponse` header methods now accept `HttpResponseHeaderValue`, improving consistency and safety.

### Example Usage:

```typescript
// Before (prone to typos)
const contentType = req.headers['content-type'];
res.headers.set('Location', '/new-resource');

// After (type-safe and autocompleted)
const contentType = req.getHeader(HttpRequestHeader.CONTENT_TYPE);
res.setHeader(HttpResponseHeader.LOCATION, '/new-resource');
```

This change significantly improves the ergonomics of working with headers in Kori, reducing common errors and making the API more intuitive.
