### PR TITLE
Configure publishConfig to exclude development field from published packages

### DIFF
--- a/packages/body-limit-plugin/package.json
+++ b/packages/body-limit-plugin/package.json
@@ -18,7 +18,19 @@
     "dist"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "exports": {
+      ".": {
+        "import": {
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        },
+        "require": {
+          "types": "./dist/index.d.cts",
+          "default": "./dist/index.cjs"
+        }
+      }
+    }
   },
   "exports": {
     ".": {

--- a/packages/cors-plugin/package.json
+++ b/packages/cors-plugin/package.json
@@ -18,7 +18,19 @@
     "dist"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "exports": {
+      ".": {
+        "import": {
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        },
+        "require": {
+          "types": "./dist/index.d.cts",
+          "default": "./dist/index.cjs"
+        }
+      }
+    }
   },
   "exports": {
     ".": {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -18,7 +18,19 @@
     "dist"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "exports": {
+      ".": {
+        "import": {
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        },
+        "require": {
+          "types": "./dist/index.d.cts",
+          "default": "./dist/index.cjs"
+        }
+      }
+    }
   },
   "exports": {
     ".": {

--- a/packages/kori/package.json
+++ b/packages/kori/package.json
@@ -18,7 +18,19 @@
     "dist"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "exports": {
+      ".": {
+        "import": {
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        },
+        "require": {
+          "types": "./dist/index.d.cts",
+          "default": "./dist/index.cjs"
+        }
+      }
+    }
   },
   "exports": {
     ".": {

--- a/packages/nodejs-adapter/package.json
+++ b/packages/nodejs-adapter/package.json
@@ -18,7 +18,19 @@
     "dist"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "exports": {
+      ".": {
+        "import": {
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        },
+        "require": {
+          "types": "./dist/index.d.cts",
+          "default": "./dist/index.cjs"
+        }
+      }
+    }
   },
   "exports": {
     ".": {

--- a/packages/openapi-plugin/package.json
+++ b/packages/openapi-plugin/package.json
@@ -18,7 +18,19 @@
     "dist"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "exports": {
+      ".": {
+        "import": {
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        },
+        "require": {
+          "types": "./dist/index.d.cts",
+          "default": "./dist/index.cjs"
+        }
+      }
+    }
   },
   "exports": {
     ".": {

--- a/packages/openapi-scalar-ui-plugin/package.json
+++ b/packages/openapi-scalar-ui-plugin/package.json
@@ -18,7 +18,19 @@
     "dist"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "exports": {
+      ".": {
+        "import": {
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        },
+        "require": {
+          "types": "./dist/index.d.cts",
+          "default": "./dist/index.cjs"
+        }
+      }
+    }
   },
   "exports": {
     ".": {

--- a/packages/pino-adapter/package.json
+++ b/packages/pino-adapter/package.json
@@ -18,7 +18,19 @@
     "dist"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "exports": {
+      ".": {
+        "import": {
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        },
+        "require": {
+          "types": "./dist/index.d.cts",
+          "default": "./dist/index.cjs"
+        }
+      }
+    }
   },
   "exports": {
     ".": {

--- a/packages/zod-openapi-plugin/package.json
+++ b/packages/zod-openapi-plugin/package.json
@@ -18,7 +18,19 @@
     "dist"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "exports": {
+      ".": {
+        "import": {
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        },
+        "require": {
+          "types": "./dist/index.d.cts",
+          "default": "./dist/index.cjs"
+        }
+      }
+    }
   },
   "exports": {
     ".": {

--- a/packages/zod-schema/package.json
+++ b/packages/zod-schema/package.json
@@ -18,7 +18,19 @@
     "dist"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "exports": {
+      ".": {
+        "import": {
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        },
+        "require": {
+          "types": "./dist/index.d.cts",
+          "default": "./dist/index.cjs"
+        }
+      }
+    }
   },
   "exports": {
     ".": {

--- a/packages/zod-validator/package.json
+++ b/packages/zod-validator/package.json
@@ -18,7 +18,19 @@
     "dist"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "exports": {
+      ".": {
+        "import": {
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        },
+        "require": {
+          "types": "./dist/index.d.cts",
+          "default": "./dist/index.cjs"
+        }
+      }
+    }
   },
   "exports": {
     ".": {


### PR DESCRIPTION
### Changes

- Add `publishConfig.exports` to all package.json files to exclude the `development` field during publishing
- Maintain `development` field for local development workflow while preventing it from being included in distributed packages

### Details

Updated 11 packages:
- `@korix/eslint-config`
- `@korix/kori` 
- `@korix/nodejs-adapter`
- `@korix/pino-adapter`
- `@korix/zod-schema`
- `@korix/zod-validator`
- `@korix/cors-plugin`
- `@korix/openapi-plugin`
- `@korix/openapi-scalar-ui-plugin`
- `@korix/body-limit-plugin`
- `@korix/zod-openapi-plugin`

### Benefits

- **Development**: Keep `development` field for faster TypeScript source resolution
- **Distribution**: Automatically exclude `development` field when publishing to npm
- **Users**: Package consumers won't see unnecessary development-specific configuration

### Configuration Added

```json
"publishConfig": {
  "access": "public",
  "exports": {
    ".": {
      "import": {
        "types": "./dist/index.d.ts",
        "default": "./dist/index.js"
      },
      "require": {
        "types": "./dist/index.d.cts",
        "default": "./dist/index.cjs"
      }
    }
  }
}
```