### PR TITLE
Remove pnpm version specification from workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,6 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
           run_install: false
 
       - name: Get pnpm store directory


### PR DESCRIPTION
Remove explicit pnpm version specification to use packageManager field

## Changes
- Remove `version: 9` from pnpm/action-setup@v4
- Use pnpm version from packageManager field (pnpm@9.15.3)