### PR TITLE
Fix changeset config baseBranch setting

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,7 +5,7 @@
   "fixed": [],
   "linked": [],
   "access": "public",
-  "baseBranch": "origin/main",
+  "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": ["@korix/example"]
 }


### PR DESCRIPTION
Fix changeset configuration to use 'main' instead of 'origin/main' as baseBranch for proper changeset operation.