### PR TITLE
Fix request body cloning to allow multiple read formats

### DIFF
--- a/.changeset/fix-request-body-cloning.md
+++ b/.changeset/fix-request-body-cloning.md
@@ -1,0 +1,7 @@
+---
+'@korix/kori': patch
+---
+
+Fix request body cloning to allow multiple read formats
+
+Previously, reading request body in different formats (e.g., json() followed by text()) would cause "body stream already read" error due to sharing the same cloned request. Each body method now creates a new clone, allowing safe mixing of different read formats while maintaining cache efficiency for repeated calls of the same format.

--- a/.changeset/optimize-pipeline-router.md
+++ b/.changeset/optimize-pipeline-router.md
@@ -1,0 +1,13 @@
+---
+'@korix/kori': patch
+'@korix/body-limit-plugin': patch
+'@korix/cors-plugin': patch
+---
+
+Optimize request/response pipeline and router
+
+- KoriRequest properties are now methods (url(), method(), headers(), etc.)
+- Router uses regex path extraction and adds fast-path routing
+- KoriResponse uses lightweight ResState with lazy header creation
+
+Breaking change: existing code needs to be updated to use the new method-based API.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -15,5 +15,9 @@
     "@korix/zod-validator": "0.0.1",
     "@korix/example": "0.1.0"
   },
-  "changesets": ["optimize-pipeline-router", "add-curly-rule"]
+  "changesets": [
+    "add-curly-rule",
+    "fix-request-body-cloning",
+    "optimize-pipeline-router"
+  ]
 }

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -15,7 +15,5 @@
     "@korix/zod-validator": "0.0.1",
     "@korix/example": "0.1.0"
   },
-  "changesets": [
-    "add-curly-rule"
-  ]
+  "changesets": ["optimize-pipeline-router", "add-curly-rule"]
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,11 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write
+      contents: write
+
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/packages/body-limit-plugin/CHANGELOG.md
+++ b/packages/body-limit-plugin/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @korix/body-limit-plugin
 
+## 0.1.0-alpha.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @korix/kori@0.1.0-alpha.2
+
 ## 0.1.0-alpha.1
 
 ### Patch Changes

--- a/packages/body-limit-plugin/package.json
+++ b/packages/body-limit-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@korix/body-limit-plugin",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "description": "Request body size limit plugin for Kori framework",
   "type": "module",
   "author": "mitz (@bufferings)",

--- a/packages/cors-plugin/CHANGELOG.md
+++ b/packages/cors-plugin/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @korix/cors-plugin
 
+## 0.1.0-alpha.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @korix/kori@0.1.0-alpha.2
+
 ## 0.1.0-alpha.1
 
 ### Patch Changes

--- a/packages/cors-plugin/package.json
+++ b/packages/cors-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@korix/cors-plugin",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "description": "CORS plugin for Kori framework",
   "type": "module",
   "author": "mitz (@bufferings)",

--- a/packages/kori/CHANGELOG.md
+++ b/packages/kori/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @korix/kori
 
+## 0.1.0-alpha.2
+
+### Patch Changes
+
+- Fix request body cloning to allow multiple read formats
+
+  Previously, reading request body in different formats (e.g., json() followed by text()) would cause "body stream already read" error due to sharing the same cloned request. Each body method now creates a new clone, allowing safe mixing of different read formats while maintaining cache efficiency for repeated calls of the same format.
+
 ## 0.1.0-alpha.1
 
 ### Patch Changes

--- a/packages/kori/package.json
+++ b/packages/kori/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@korix/kori",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "type": "module",
   "description": "A modern TypeScript web framework",
   "author": "mitz (@bufferings)",

--- a/packages/kori/src/context/request.ts
+++ b/packages/kori/src/context/request.ts
@@ -42,7 +42,6 @@ type BodyCache = {
   text?: Promise<string>;
   formData?: Promise<FormData>;
   arrayBuffer?: Promise<ArrayBuffer>;
-  stream?: ReadableStream<Uint8Array> | null;
 };
 
 type ReqState<PathParams extends Record<string, string>> = {
@@ -145,8 +144,7 @@ function getBodyArrayBufferInternal(req: ReqStateAny): Promise<ArrayBuffer> {
 }
 
 function getBodyStreamInternal(req: ReqStateAny): ReadableStream | null {
-  req.bodyCache.stream ??= req.raw.clone().body;
-  return req.bodyCache.stream;
+  return req.raw.clone().body;
 }
 
 function parseBodyInternal(req: ReqStateAny): Promise<unknown> {

--- a/packages/kori/src/context/request.ts
+++ b/packages/kori/src/context/request.ts
@@ -144,6 +144,7 @@ function getBodyArrayBufferInternal(req: ReqStateAny): Promise<ArrayBuffer> {
 }
 
 function getBodyStreamInternal(req: ReqStateAny): ReadableStream | null {
+  // Don't cache stream - ReadableStreams are single-use and can't be reused after consumption
   return req.raw.clone().body;
 }
 

--- a/packages/kori/src/context/request.ts
+++ b/packages/kori/src/context/request.ts
@@ -38,11 +38,11 @@ export type KoriRequest<PathParams extends Record<string, string> = Record<strin
 type KoriRequestAny = KoriRequest<any>;
 
 type BodyCache = {
-  body?: ReadableStream<Uint8Array> | null;
   json?: Promise<unknown>;
   text?: Promise<string>;
   formData?: Promise<FormData>;
   arrayBuffer?: Promise<ArrayBuffer>;
+  stream?: ReadableStream<Uint8Array> | null;
 };
 
 type ReqState<PathParams extends Record<string, string>> = {
@@ -62,11 +62,6 @@ type ReqState<PathParams extends Record<string, string>> = {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ReqStateAny = ReqState<any>;
-
-function cloneRaw(req: ReqStateAny): Request {
-  req.clonedRawRequest ??= req.raw.clone();
-  return req.clonedRawRequest;
-}
 
 function getLogInternal(req: ReqStateAny): KoriLogger {
   req.logCache ??= req.rootLogger.child('request');
@@ -130,28 +125,28 @@ function getContentTypeInternal(req: ReqStateAny): ContentTypeValue | undefined 
 }
 
 function getBodyJsonInternal(req: ReqStateAny): Promise<unknown> {
-  req.bodyCache.json ??= cloneRaw(req).json();
+  req.bodyCache.json ??= req.raw.clone().json();
   return req.bodyCache.json;
 }
 
 function getBodyTextInternal(req: ReqStateAny): Promise<string> {
-  req.bodyCache.text ??= cloneRaw(req).text();
+  req.bodyCache.text ??= req.raw.clone().text();
   return req.bodyCache.text;
 }
 
 function getBodyFormDataInternal(req: ReqStateAny): Promise<FormData> {
-  req.bodyCache.formData ??= cloneRaw(req).formData();
+  req.bodyCache.formData ??= req.raw.clone().formData();
   return req.bodyCache.formData;
 }
 
 function getBodyArrayBufferInternal(req: ReqStateAny): Promise<ArrayBuffer> {
-  req.bodyCache.arrayBuffer ??= cloneRaw(req).arrayBuffer();
+  req.bodyCache.arrayBuffer ??= req.raw.clone().arrayBuffer();
   return req.bodyCache.arrayBuffer;
 }
 
 function getBodyStreamInternal(req: ReqStateAny): ReadableStream | null {
-  req.bodyCache.body ??= cloneRaw(req).body;
-  return req.bodyCache.body;
+  req.bodyCache.stream ??= req.raw.clone().body;
+  return req.bodyCache.stream;
 }
 
 function parseBodyInternal(req: ReqStateAny): Promise<unknown> {

--- a/packages/nodejs-adapter/CHANGELOG.md
+++ b/packages/nodejs-adapter/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @korix/nodejs-adapter
 
+## 0.1.0-alpha.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @korix/kori@0.1.0-alpha.2
+
 ## 0.1.0-alpha.1
 
 ### Patch Changes

--- a/packages/nodejs-adapter/package.json
+++ b/packages/nodejs-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@korix/nodejs-adapter",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "description": "Node.js adapter for Kori framework",
   "type": "module",
   "author": "mitz (@bufferings)",

--- a/packages/openapi-plugin/CHANGELOG.md
+++ b/packages/openapi-plugin/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @korix/openapi-plugin
 
+## 0.1.0-alpha.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @korix/kori@0.1.0-alpha.2
+
 ## 0.1.0-alpha.1
 
 ### Patch Changes

--- a/packages/openapi-plugin/package.json
+++ b/packages/openapi-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@korix/openapi-plugin",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "description": "OpenAPI plugin for Kori framework",
   "type": "module",
   "author": "mitz (@bufferings)",

--- a/packages/openapi-scalar-ui-plugin/CHANGELOG.md
+++ b/packages/openapi-scalar-ui-plugin/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @korix/openapi-scalar-ui-plugin
 
+## 0.1.0-alpha.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @korix/kori@0.1.0-alpha.2
+  - @korix/openapi-plugin@0.1.0-alpha.2
+
 ## 0.1.0-alpha.1
 
 ### Patch Changes

--- a/packages/openapi-scalar-ui-plugin/package.json
+++ b/packages/openapi-scalar-ui-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@korix/openapi-scalar-ui-plugin",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "description": "Scalar UI plugin for OpenAPI documentation in Kori framework",
   "type": "module",
   "author": "mitz (@bufferings)",

--- a/packages/pino-adapter/CHANGELOG.md
+++ b/packages/pino-adapter/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @korix/pino-adapter
 
+## 0.1.0-alpha.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @korix/kori@0.1.0-alpha.2
+
 ## 0.1.0-alpha.1
 
 ### Patch Changes

--- a/packages/pino-adapter/package.json
+++ b/packages/pino-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@korix/pino-adapter",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "description": "Pino logger adapter for Kori framework",
   "type": "module",
   "author": "mitz (@bufferings)",

--- a/packages/zod-openapi-plugin/CHANGELOG.md
+++ b/packages/zod-openapi-plugin/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @korix/zod-openapi-plugin
 
+## 0.1.0-alpha.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @korix/kori@0.1.0-alpha.2
+  - @korix/openapi-plugin@0.1.0-alpha.2
+  - @korix/zod-schema@0.1.0-alpha.2
+
 ## 0.1.0-alpha.1
 
 ### Patch Changes

--- a/packages/zod-openapi-plugin/package.json
+++ b/packages/zod-openapi-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@korix/zod-openapi-plugin",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "description": "OpenAPI plugin for Zod schemas in Kori framework",
   "type": "module",
   "author": "mitz (@bufferings)",

--- a/packages/zod-schema/CHANGELOG.md
+++ b/packages/zod-schema/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @korix/zod-schema
 
+## 0.1.0-alpha.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @korix/kori@0.1.0-alpha.2
+
 ## 0.1.0-alpha.1
 
 ### Patch Changes

--- a/packages/zod-schema/package.json
+++ b/packages/zod-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@korix/zod-schema",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "description": "Zod schema integration for Kori framework",
   "type": "module",
   "author": "mitz (@bufferings)",

--- a/packages/zod-validator/CHANGELOG.md
+++ b/packages/zod-validator/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @korix/zod-validator
 
+## 0.1.0-alpha.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @korix/kori@0.1.0-alpha.2
+  - @korix/zod-schema@0.1.0-alpha.2
+
 ## 0.1.0-alpha.1
 
 ### Patch Changes

--- a/packages/zod-validator/package.json
+++ b/packages/zod-validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@korix/zod-validator",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "description": "Zod validator for Kori framework",
   "type": "module",
   "author": "mitz (@bufferings)",


### PR DESCRIPTION
Fix request body cloning issue that prevented mixing different body read formats (json, text, etc). Each body method now creates a new clone to avoid stream consumption errors. Bump @korix/kori to 0.1.0-alpha.2.