### PR TITLE
feat: Add security-headers-plugin with modern CSP-first design

### DIFF
--- a/.changeset/initial-security-headers-plugin.md
+++ b/.changeset/initial-security-headers-plugin.md
@@ -1,8 +1,6 @@
-# @korix/security-headers-plugin
-
-## 0.1.0-alpha.1
-
-### Patch Changes
+---
+'@korix/security-headers-plugin': patch
+---
 
 Initial release of security headers plugin for Kori framework
 

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -13,8 +13,9 @@
     "@korix/zod-openapi-plugin": "0.0.1",
     "@korix/zod-schema": "0.0.1",
     "@korix/zod-validator": "0.0.1",
-    "@korix/example": "0.1.0",
-    "@korix/script": "0.0.1"
+    "@korix/script": "0.0.1",
+    "@korix/security-headers-plugin": "0.0.1",
+    "@korix/example": "0.1.0"
   },
   "changesets": [
     "add-curly-rule",
@@ -23,6 +24,7 @@
     "dev-tooling-updates",
     "eslint-config-updates",
     "fix-request-body-cloning",
+    "initial-security-headers-plugin",
     "kori-fix-415-status",
     "optimize-pipeline-router",
     "refactor-logger-as-method",

--- a/packages/security-headers-plugin/package.json
+++ b/packages/security-headers-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@korix/security-headers-plugin",
-  "version": "0.1.0-alpha.0",
+  "version": "0.1.0-alpha.1",
   "description": "Security headers plugin for Kori framework",
   "type": "module",
   "author": "mitz (@bufferings)",

--- a/packages/security-headers-plugin/src/version.ts
+++ b/packages/security-headers-plugin/src/version.ts
@@ -1,1 +1,1 @@
-export const PLUGIN_VERSION = '0.1.0-alpha.0';
+export const PLUGIN_VERSION = '0.1.0-alpha.1';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "./packages/openapi-plugin" },
     { "path": "./packages/openapi-scalar-ui-plugin" },
     { "path": "./packages/pino-adapter" },
+    { "path": "./packages/security-headers-plugin" },
     { "path": "./packages/zod-openapi-plugin" },
     { "path": "./packages/zod-schema" },
     { "path": "./packages/zod-validator" }


### PR DESCRIPTION
## Summary

This PR introduces a new  for the Kori framework with a modern, Content-Security-Policy (CSP) first design approach.

## Key Features

- **CSP-First Design**: The plugin is centered around the  header as the primary configuration method
- **Automatic Backward Compatibility**: When  is configured, the legacy  header is automatically set for older browser support
- **Security Best Practices**: 
  -  is always set to  to disable deprecated browser XSS auditors (not configurable)
  - Secure defaults for all headers
  - Default clickjacking protection with 

## Supported Headers

-  (with object-based directive configuration)
-  (auto-configured based on frame-ancestors)
- 
-  (fixed to '0')
- 
- 
- 
- 
- 
- 
- 

## Additional Features

- Custom header support
- Path-based header skipping with string/regex patterns
- Comprehensive TypeScript types
- Detailed logging

## Breaking Changes

None - this is an initial release (v0.1.0-alpha.1).

## Testing

All existing tests pass and the plugin follows modern security header best practices.