### PR TITLE
Standardize ESLint config import to use koriConfig

### DIFF
--- a/packages/body-limit-plugin/eslint.config.js
+++ b/packages/body-limit-plugin/eslint.config.js
@@ -1,7 +1,7 @@
-import eslintConfig from '@korix/eslint-config';
+import { koriConfig } from '@korix/eslint-config';
 
 export default [
-  ...eslintConfig,
+  ...koriConfig,
   {
     languageOptions: {
       parserOptions: {

--- a/packages/cors-plugin/eslint.config.js
+++ b/packages/cors-plugin/eslint.config.js
@@ -1,7 +1,7 @@
-import eslintConfig from '@korix/eslint-config';
+import { koriConfig } from '@korix/eslint-config';
 
 export default [
-  ...eslintConfig,
+  ...koriConfig,
   {
     languageOptions: {
       parserOptions: {

--- a/packages/eslint-config/eslint.config.js
+++ b/packages/eslint-config/eslint.config.js
@@ -1,7 +1,7 @@
-import eslintConfig from './dist/index.js';
+import { koriConfig } from './dist/index.js';
 
 export default [
-  ...eslintConfig,
+  ...koriConfig,
   {
     languageOptions: {
       parserOptions: {

--- a/packages/example/eslint.config.js
+++ b/packages/example/eslint.config.js
@@ -1,7 +1,7 @@
-import eslintConfig from '@korix/eslint-config';
+import { koriConfig } from '@korix/eslint-config';
 
 export default [
-  ...eslintConfig,
+  ...koriConfig,
   {
     languageOptions: {
       parserOptions: {

--- a/packages/kori/eslint.config.js
+++ b/packages/kori/eslint.config.js
@@ -1,7 +1,7 @@
-import eslintConfig from '@korix/eslint-config';
+import { koriConfig } from '@korix/eslint-config';
 
 export default [
-  ...eslintConfig,
+  ...koriConfig,
   {
     languageOptions: {
       parserOptions: {

--- a/packages/nodejs-adapter/eslint.config.js
+++ b/packages/nodejs-adapter/eslint.config.js
@@ -1,7 +1,7 @@
-import eslintConfig from '@korix/eslint-config';
+import { koriConfig } from '@korix/eslint-config';
 
 export default [
-  ...eslintConfig,
+  ...koriConfig,
   {
     languageOptions: {
       parserOptions: {

--- a/packages/openapi-plugin/eslint.config.js
+++ b/packages/openapi-plugin/eslint.config.js
@@ -1,7 +1,7 @@
-import eslintConfig from '@korix/eslint-config';
+import { koriConfig } from '@korix/eslint-config';
 
 export default [
-  ...eslintConfig,
+  ...koriConfig,
   {
     languageOptions: {
       parserOptions: {

--- a/packages/openapi-scalar-ui-plugin/eslint.config.js
+++ b/packages/openapi-scalar-ui-plugin/eslint.config.js
@@ -1,7 +1,7 @@
-import eslintConfig from '@korix/eslint-config';
+import { koriConfig } from '@korix/eslint-config';
 
 export default [
-  ...eslintConfig,
+  ...koriConfig,
   {
     languageOptions: {
       parserOptions: {

--- a/packages/pino-adapter/eslint.config.js
+++ b/packages/pino-adapter/eslint.config.js
@@ -1,7 +1,7 @@
-import eslintConfig from '@korix/eslint-config';
+import { koriConfig } from '@korix/eslint-config';
 
 export default [
-  ...eslintConfig,
+  ...koriConfig,
   {
     languageOptions: {
       parserOptions: {

--- a/packages/script/eslint.config.js
+++ b/packages/script/eslint.config.js
@@ -1,7 +1,7 @@
-import eslintConfig from '@korix/eslint-config';
+import { koriConfig } from '@korix/eslint-config';
 
 export default [
-  ...eslintConfig,
+  ...koriConfig,
   {
     languageOptions: {
       parserOptions: {

--- a/packages/security-headers-plugin/eslint.config.js
+++ b/packages/security-headers-plugin/eslint.config.js
@@ -1,7 +1,7 @@
-import eslintConfig from '@korix/eslint-config';
+import { koriConfig } from '@korix/eslint-config';
 
 export default [
-  ...eslintConfig,
+  ...koriConfig,
   {
     languageOptions: {
       parserOptions: {

--- a/packages/zod-openapi-plugin/eslint.config.js
+++ b/packages/zod-openapi-plugin/eslint.config.js
@@ -1,7 +1,7 @@
-import eslintConfig from '@korix/eslint-config';
+import { koriConfig } from '@korix/eslint-config';
 
 export default [
-  ...eslintConfig,
+  ...koriConfig,
   {
     languageOptions: {
       parserOptions: {

--- a/packages/zod-schema/eslint.config.js
+++ b/packages/zod-schema/eslint.config.js
@@ -1,7 +1,7 @@
-import eslintConfig from '@korix/eslint-config';
+import { koriConfig } from '@korix/eslint-config';
 
 export default [
-  ...eslintConfig,
+  ...koriConfig,
   {
     languageOptions: {
       parserOptions: {

--- a/packages/zod-validator/eslint.config.js
+++ b/packages/zod-validator/eslint.config.js
@@ -1,7 +1,7 @@
-import eslintConfig from '@korix/eslint-config';
+import { koriConfig } from '@korix/eslint-config';
 
 export default [
-  ...eslintConfig,
+  ...koriConfig,
   {
     languageOptions: {
       parserOptions: {


### PR DESCRIPTION
Unify import naming across all packages from eslintConfig to koriConfig for consistency throughout the codebase.

This change:
- Updates 14 eslint.config.js files across all packages
- Changes import from default import to named import
- Improves code consistency without affecting public APIs
- No breaking changes or version bumps needed