### PR TITLE
feat: Add chunked transfer encoding support to body-limit-plugin

### DIFF
--- a/.changeset/body-limit-chunked-encoding.md
+++ b/.changeset/body-limit-chunked-encoding.md
@@ -1,0 +1,10 @@
+---
+'@korix/body-limit-plugin': patch
+---
+
+Add chunked transfer encoding support to body-limit-plugin
+
+- Add enableChunkedSupport option to enable stream size monitoring for chunked requests
+- Implement real-time size checking that works without Content-Length header
+- Preserve existing Content-Length validation behavior for backward compatibility
+- Add comprehensive logging for chunked encoding processing


### PR DESCRIPTION
This PR adds support for chunked transfer encoding to the body-limit-plugin, allowing size monitoring of request bodies that don't have Content-Length headers.

## Key Changes

- Add `enableChunkedSupport` option to BodyLimitOptions
- Implement `createSizeLimitedStream` for real-time size monitoring
- Add stream wrapping logic for chunked requests
- Preserve existing Content-Length validation behavior
- Add comprehensive logging for chunked encoding processing

## Benefits

- Memory efficient: checks size without loading entire body into memory
- Early termination: stops stream processing when limit exceeded
- Backward compatible: existing Content-Length processing unchanged
- Opt-in feature: requires explicit enablement via enableChunkedSupport flag

## Usage

```typescript
app.applyPlugin(bodyLimitPlugin({
  maxSize: 1024 * 1024, // 1MB
  enableChunkedSupport: true // Enable chunked encoding support
}));
```

Resolves the TODO comment about chunked transfer encoding support.