### PR TITLE
Add static file serving plugin for Node.js

### DIFF
--- a/.changeset/error-helpers-improvement.md
+++ b/.changeset/error-helpers-improvement.md
@@ -1,0 +1,27 @@
+---
+'@korix/static-file-plugin-nodejs': patch
+---
+
+Use KoriResponse error helper methods for better consistency
+
+Replace manual status/json error responses with built-in helper methods:
+
+- `res.status(404).json({...})` → `res.notFound({...})`
+- `res.status(403).json({...})` → `res.forbidden({...})`
+
+This provides structured error responses with consistent format:
+
+```json
+{
+  "error": {
+    "type": "NOT_FOUND",
+    "message": "File not found"
+  }
+}
+```
+
+Benefits:
+
+- Consistent error format across all Kori applications
+- More concise and readable code
+- Reduced chance of typos in status codes

--- a/.changeset/header-constants-standardization.md
+++ b/.changeset/header-constants-standardization.md
@@ -1,0 +1,15 @@
+---
+'@korix/kori': patch
+'@korix/static-file-plugin-nodejs': patch
+'@korix/security-headers-plugin': patch
+'@korix/example': patch
+---
+
+Standardize HTTP header names using constants
+
+Replace hardcoded header strings with HttpResponseHeader constants for better consistency and type safety:
+
+- Add missing header constants to HttpResponseHeader (cache-control, content-length, etag, etc.)
+- Replace hardcoded strings like 'cache-control', 'etag' with HttpResponseHeader.CACHE_CONTROL, HttpResponseHeader.ETAG
+- Apply standardization across all plugins and examples
+- Improve typo prevention and code maintainability

--- a/.changeset/method-chaining-api-standardization.md
+++ b/.changeset/method-chaining-api-standardization.md
@@ -1,0 +1,13 @@
+---
+'@korix/kori': patch
+'@korix/static-file-plugin-nodejs': patch
+---
+
+Standardize response methods to use method chaining pattern
+
+Response body methods now require method chaining for setting status codes:
+
+- `res.json(body, 404)` → `res.status(404).json(body)`
+- `res.text(body, 201)` → `res.status(201).text(body)`
+- `res.empty(304)` → `res.status(304).empty()`
+- `res.stream(data, 200)` → `res.status(200).stream(data)`

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -13,6 +13,7 @@
     "@korix/pino-adapter": "0.1.0",
     "@korix/script": "0.1.0",
     "@korix/security-headers-plugin": "0.1.0",
+    "@korix/static-file-plugin-nodejs": "0.1.0",
     "@korix/zod-openapi-plugin": "0.1.0",
     "@korix/zod-schema": "0.1.0",
     "@korix/zod-validator": "0.1.0"

--- a/.changeset/response-content-type-optimization.md
+++ b/.changeset/response-content-type-optimization.md
@@ -2,6 +2,7 @@
 '@korix/kori': patch
 ---
 
-Fix Content-Type header preservation in KoriResponse
+Fix header and status code preservation in KoriResponse
 
-Fix: `setHeader('content-type', 'custom')` now preserved when calling body methods like `stream()` or `json()`
+- Fix: `setHeader('content-type', 'custom')` now preserved when calling body methods like `stream()` or `json()`
+- Fix: `status(400).empty()` now preserves the status code instead of overwriting with 204

--- a/.changeset/response-content-type-optimization.md
+++ b/.changeset/response-content-type-optimization.md
@@ -1,0 +1,7 @@
+---
+'@korix/kori': patch
+---
+
+Fix Content-Type header preservation in KoriResponse
+
+Fix: `setHeader('content-type', 'custom')` now preserved when calling body methods like `stream()` or `json()`

--- a/.changeset/static-file-plugin-nodejs.md
+++ b/.changeset/static-file-plugin-nodejs.md
@@ -1,0 +1,7 @@
+---
+'@korix/static-file-plugin-nodejs': patch
+---
+
+Add static file serving plugin for Node.js
+
+Provides secure static file serving with streaming, MIME type detection, and caching headers.

--- a/.changeset/status-code-constants-improvement.md
+++ b/.changeset/status-code-constants-improvement.md
@@ -1,0 +1,19 @@
+---
+'@korix/example': patch
+---
+
+Replace hardcoded status codes with constants and error helpers
+
+Replace manual status code numbers with proper constants and helper methods:
+
+- `res.status(400).json({...})` → `res.badRequest({...})`
+- `res.status(401).json({...})` → `res.unauthorized({...})`
+- `res.status(500).json({...})` → `res.internalError({...})`
+- `res.status(201)` → `res.status(HttpStatus.CREATED)`
+
+Benefits:
+
+- Type safety and IntelliSense support
+- Consistent error response format with structured JSON
+- Reduced chance of typos in status codes
+- More expressive and readable code

--- a/packages/example/src/cookie-example.ts
+++ b/packages/example/src/cookie-example.ts
@@ -82,7 +82,7 @@ app.get('/profile', ({ req, res }) => {
   const username = req.cookie('username');
 
   if (!sessionId) {
-    return res.status(401).json({
+    return res.unauthorized({
       message: 'Login required',
     });
   }

--- a/packages/example/src/getting-started.ts
+++ b/packages/example/src/getting-started.ts
@@ -1,4 +1,4 @@
-import { createKori } from '@korix/kori';
+import { createKori, HttpStatus } from '@korix/kori';
 import { startNodeServer } from '@korix/nodejs-adapter';
 import { scalarUiPlugin } from '@korix/openapi-scalar-ui-plugin';
 import { zodOpenApiPlugin, openApiMeta } from '@korix/zod-openapi-plugin';
@@ -65,7 +65,7 @@ app.post('/users', {
       email,
       createdAt: new Date().toISOString(),
     };
-    return ctx.res.status(201).json(newUser);
+    return ctx.res.status(HttpStatus.CREATED).json(newUser);
   },
 });
 

--- a/packages/example/src/streaming-example.ts
+++ b/packages/example/src/streaming-example.ts
@@ -48,7 +48,7 @@ app.post('/upload-stream', {
     // Check if request has a body stream
     const bodyStream = koriReq.bodyStream();
     if (!bodyStream) {
-      return res.status(400).json({ error: 'No request body' });
+      return res.badRequest({ message: 'No request body' });
     }
 
     // Process the stream without loading it entirely into memory
@@ -86,7 +86,7 @@ app.post('/upload-stream', {
       });
     } catch (error) {
       ctx.req.log().error('Upload error', { error });
-      return res.status(500).json({ error: 'Upload failed' });
+      return res.internalError({ message: 'Upload failed' });
     }
   },
 });

--- a/packages/example/src/streaming-example.ts
+++ b/packages/example/src/streaming-example.ts
@@ -1,4 +1,4 @@
-import { createKori } from '@korix/kori';
+import { createKori, HttpResponseHeader } from '@korix/kori';
 import { type KoriRequest } from '@korix/kori';
 import { startNodeServer } from '@korix/nodejs-adapter';
 
@@ -29,10 +29,10 @@ app.get('/events', {
 
     // Return streaming response with SSE headers
     return ctx.res
-      .setHeader('Content-Type', 'text/event-stream')
-      .setHeader('Cache-Control', 'no-cache')
-      .setHeader('Connection', 'keep-alive')
-      .setHeader('Access-Control-Allow-Origin', '*')
+      .setHeader(HttpResponseHeader.CONTENT_TYPE, 'text/event-stream')
+      .setHeader(HttpResponseHeader.CACHE_CONTROL, 'no-cache')
+      .setHeader(HttpResponseHeader.CONNECTION, 'keep-alive')
+      .setHeader(HttpResponseHeader.ACCESS_CONTROL_ALLOW_ORIGIN, '*')
       .stream(transformStream.readable);
   },
 });
@@ -121,8 +121,8 @@ app.get('/download-stream', {
     });
 
     return ctx.res
-      .setHeader('Content-Type', 'text/plain')
-      .setHeader('Content-Disposition', 'attachment; filename="stream.txt"')
+      .setHeader(HttpResponseHeader.CONTENT_TYPE, 'text/plain')
+      .setHeader(HttpResponseHeader.CONTENT_DISPOSITION, 'attachment; filename="stream.txt"')
       .stream(stream);
   },
 });

--- a/packages/example/src/usage.ts
+++ b/packages/example/src/usage.ts
@@ -3,6 +3,7 @@ import {
   createKori,
   defineKoriPlugin,
   HttpRequestHeader,
+  HttpStatus,
   type KoriEnvironment,
   type KoriRequest,
   type KoriResponse,
@@ -158,7 +159,7 @@ app.post('/products', {
       requestId: ctx.req.requestId,
     });
 
-    return ctx.res.status(201).json(newProduct);
+    return ctx.res.status(HttpStatus.CREATED).json(newProduct);
   },
 });
 
@@ -232,8 +233,7 @@ app.createChild({
       .onError((ctx, err) => {
         const error = err instanceof Error ? err : new Error(String(err));
         if (error.message === 'Unauthorized' && !ctx.res.isReady()) {
-          ctx.res.status(401).json({
-            error: 'Unauthorized',
+          ctx.res.unauthorized({
             message: 'Admin access required. Use Authorization: Bearer admin-secret-token',
           });
         }

--- a/packages/kori/src/context/response.ts
+++ b/packages/kori/src/context/response.ts
@@ -214,7 +214,7 @@ function setErrorInternal({ res, errorType, defaultMsg, status, options = {} }: 
 
 function getFinalStatusCode(res: ResState): HttpStatusCode {
   if (res.statusCode === null) {
-    if (res.bodyKind === 'none' || res.bodyKind === 'empty') {
+    if (res.bodyKind === 'empty') {
       return HttpStatus.NO_CONTENT;
     } else {
       return HttpStatus.OK;

--- a/packages/kori/src/context/response.ts
+++ b/packages/kori/src/context/response.ts
@@ -412,10 +412,10 @@ const sharedMethods = {
     return new Headers(getFinalHeaders(this));
   },
   getHeader(name: HttpResponseHeaderName): string | undefined {
-    return this.headers?.get(name) ?? undefined;
+    return getFinalHeaders(this).get(name) ?? undefined;
   },
   getContentType(): string | undefined {
-    return this.headers?.get(HttpResponseHeader.CONTENT_TYPE) ?? undefined;
+    return getFinalHeaders(this).get(HttpResponseHeader.CONTENT_TYPE) ?? undefined;
   },
   getBody(): unknown {
     return this.bodyValue;

--- a/packages/kori/src/context/response.ts
+++ b/packages/kori/src/context/response.ts
@@ -42,11 +42,11 @@ export type KoriResponse = {
   setCookie(name: string, value: CookieValue, options?: CookieOptions): KoriResponse;
   clearCookie(name: string, options?: Pick<CookieOptions, 'path' | 'domain'>): KoriResponse;
 
-  json<T>(body: T, statusCode?: HttpStatusCode): KoriResponse;
-  text(body: string, statusCode?: HttpStatusCode): KoriResponse;
-  html(body: string, statusCode?: HttpStatusCode): KoriResponse;
-  empty(statusCode?: HttpStatusCode): KoriResponse;
-  stream(body: ReadableStream, statusCode?: HttpStatusCode): KoriResponse;
+  json<T>(body: T): KoriResponse;
+  text(body: string): KoriResponse;
+  html(body: string): KoriResponse;
+  empty(): KoriResponse;
+  stream(body: ReadableStream): KoriResponse;
 
   badRequest(options?: ErrorResponseOptions): KoriResponse;
   unauthorized(options?: ErrorResponseOptions): KoriResponse;
@@ -81,32 +81,21 @@ export function isKoriResponse(value: unknown): value is KoriResponse {
   return typeof value === 'object' && value !== null && KoriResponseBrand in value;
 }
 
-function ensureHeaders(res: ResState): void {
-  res.headers ??= new Headers();
-}
-
 function setHeaderInternal(res: ResState, name: HttpResponseHeaderName, value: string): void {
-  ensureHeaders(res);
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  res.headers!.set(name, value);
+  res.headers ??= new Headers();
+  res.headers.set(name, value);
 }
 
 function appendHeaderInternal(res: ResState, name: HttpResponseHeaderName, value: string): void {
-  ensureHeaders(res);
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  res.headers!.append(name, value);
+  res.headers ??= new Headers();
+  res.headers.append(name, value);
 }
 
 function removeHeaderInternal(res: ResState, name: HttpResponseHeaderName): void {
   if (!res.headers) {
     return;
   }
-  ensureHeaders(res);
   res.headers.delete(name);
-}
-
-function setStatusInternal(res: ResState, code: HttpStatusCode): void {
-  res.statusCode = code;
 }
 
 function setCookieInternal(res: ResState, name: string, value: CookieValue, options?: CookieOptions): void {
@@ -122,52 +111,35 @@ function clearCookieInternal(res: ResState, name: string, options?: Pick<CookieO
 type BodyConfig<T> = {
   res: ResState;
   body: T;
-  code?: HttpStatusCode;
 };
 
-function setBodyJsonInternal<T>({ res, body, code }: BodyConfig<T>): void {
+function setBodyJsonInternal<T>({ res, body }: BodyConfig<T>): void {
   res.bodyKind = 'json';
   res.bodyValue = JSON.stringify(body);
-  if (code) {
-    res.statusCode = code;
-  }
 }
 
-function setBodyTextInternal({ res, body, code }: BodyConfig<string>): void {
+function setBodyTextInternal({ res, body }: BodyConfig<string>): void {
   res.bodyKind = 'text';
   res.bodyValue = body;
-  if (code) {
-    res.statusCode = code;
-  }
 }
 
-function setBodyHtmlInternal({ res, body, code }: BodyConfig<string>): void {
+function setBodyHtmlInternal({ res, body }: BodyConfig<string>): void {
   res.bodyKind = 'html';
   res.bodyValue = body;
-  if (code) {
-    res.statusCode = code;
-  }
 }
 
 type EmptyBodyConfig = {
   res: ResState;
-  code?: HttpStatusCode;
 };
 
-function setBodyEmptyInternal({ res, code }: EmptyBodyConfig): void {
+function setBodyEmptyInternal({ res }: EmptyBodyConfig): void {
   res.bodyKind = 'empty';
   res.bodyValue = undefined;
-  if (code) {
-    res.statusCode = code;
-  }
 }
 
-function setBodyStreamInternal({ res, body, code }: BodyConfig<ReadableStream>): void {
+function setBodyStreamInternal({ res, body }: BodyConfig<ReadableStream>): void {
   res.bodyKind = 'stream';
   res.bodyValue = body;
-  if (code) {
-    res.statusCode = code;
-  }
 }
 
 type ErrorType =
@@ -229,13 +201,13 @@ type ErrorConfig = {
 
 function setErrorInternal({ res, errorType, defaultMsg, status, options = {} }: ErrorConfig): void {
   const msg = options.message ?? defaultMsg;
+  res.statusCode = status;
   if (options.type === 'text') {
-    setBodyTextInternal({ res, body: msg, code: status });
+    setBodyTextInternal({ res, body: msg });
   } else {
     setBodyJsonInternal({
       res,
       body: createErrorResponseBodyJson({ errorType, message: msg, details: options.details }),
-      code: status,
     });
   }
 }
@@ -284,7 +256,7 @@ function getFinalHeaders(res: ResState): Headers {
 
 const sharedMethods = {
   status(code: HttpStatusCode): KoriResponse {
-    setStatusInternal(this, code);
+    this.statusCode = code;
     return this as unknown as KoriResponse;
   },
 
@@ -310,24 +282,24 @@ const sharedMethods = {
     return this as unknown as KoriResponse;
   },
 
-  json<T>(body: T, code?: HttpStatusCode): KoriResponse {
-    setBodyJsonInternal({ res: this, body, code });
+  json<T>(body: T): KoriResponse {
+    setBodyJsonInternal({ res: this, body });
     return this as unknown as KoriResponse;
   },
-  text(body: string, code?: HttpStatusCode): KoriResponse {
-    setBodyTextInternal({ res: this, body, code });
+  text(body: string): KoriResponse {
+    setBodyTextInternal({ res: this, body });
     return this as unknown as KoriResponse;
   },
-  html(body: string, code?: HttpStatusCode): KoriResponse {
-    setBodyHtmlInternal({ res: this, body, code });
+  html(body: string): KoriResponse {
+    setBodyHtmlInternal({ res: this, body });
     return this as unknown as KoriResponse;
   },
-  empty(code?: HttpStatusCode): KoriResponse {
-    setBodyEmptyInternal({ res: this, code });
+  empty(): KoriResponse {
+    setBodyEmptyInternal({ res: this });
     return this as unknown as KoriResponse;
   },
-  stream(body: ReadableStream, code?: HttpStatusCode): KoriResponse {
-    setBodyStreamInternal({ res: this, body, code });
+  stream(body: ReadableStream): KoriResponse {
+    setBodyStreamInternal({ res: this, body });
     return this as unknown as KoriResponse;
   },
 

--- a/packages/kori/src/http/headers.ts
+++ b/packages/kori/src/http/headers.ts
@@ -30,14 +30,29 @@ export type HttpRequestHeaderName = (typeof HttpRequestHeader)[keyof typeof Http
  */
 export const HttpResponseHeader = {
   ACCESS_CONTROL_ALLOW_ORIGIN: 'access-control-allow-origin',
+  CACHE_CONTROL: 'cache-control',
+  CONNECTION: 'connection',
+  CONTENT_DISPOSITION: 'content-disposition',
   CONTENT_ENCODING: 'content-encoding',
+  CONTENT_LENGTH: 'content-length',
+  CONTENT_SECURITY_POLICY: 'content-security-policy',
   CONTENT_TYPE: 'content-type',
+  CROSS_ORIGIN_EMBEDDER_POLICY: 'cross-origin-embedder-policy',
+  CROSS_ORIGIN_OPENER_POLICY: 'cross-origin-opener-policy',
+  CROSS_ORIGIN_RESOURCE_POLICY: 'cross-origin-resource-policy',
   ETAG: 'etag',
+  LAST_MODIFIED: 'last-modified',
   LOCATION: 'location',
+  REFERRER_POLICY: 'referrer-policy',
   SET_COOKIE: 'set-cookie',
   STRICT_TRANSPORT_SECURITY: 'strict-transport-security',
   VARY: 'vary',
   WWW_AUTHENTICATE: 'www-authenticate',
+  X_CONTENT_TYPE_OPTIONS: 'x-content-type-options',
+  X_DOWNLOAD_OPTIONS: 'x-download-options',
+  X_FRAME_OPTIONS: 'x-frame-options',
+  X_PERMITTED_CROSS_DOMAIN_POLICIES: 'x-permitted-cross-domain-policies',
+  X_XSS_PROTECTION: 'x-xss-protection',
 } as const;
 
 export type HttpResponseHeaderName = (typeof HttpResponseHeader)[keyof typeof HttpResponseHeader] | (string & {});

--- a/packages/kori/tests/context/response-header-consistency.test.ts
+++ b/packages/kori/tests/context/response-header-consistency.test.ts
@@ -1,0 +1,83 @@
+import { describe, test, expect } from 'vitest';
+
+import { createKoriResponse } from '../../src/context/response.js';
+import { HttpResponseHeader, ContentTypeUtf8 } from '../../src/http/index.js';
+
+describe('KoriResponse header consistency', () => {
+  test('getContentType() returns correct value after res.json()', () => {
+    const res = createKoriResponse();
+
+    // Before calling json(), getContentType should return undefined
+    expect(res.getContentType()).toBeUndefined();
+
+    // After calling json(), getContentType should return the default Content-Type
+    res.json({ message: 'test' });
+    expect(res.getContentType()).toBe(ContentTypeUtf8.APPLICATION_JSON);
+
+    // The built response should have the same Content-Type
+    const response = res.build();
+    expect(response.headers.get(HttpResponseHeader.CONTENT_TYPE)).toBe(ContentTypeUtf8.APPLICATION_JSON);
+  });
+
+  test('getContentType() returns correct value after res.text()', () => {
+    const res = createKoriResponse();
+
+    res.text('Hello World');
+    expect(res.getContentType()).toBe(ContentTypeUtf8.TEXT_PLAIN);
+
+    const response = res.build();
+    expect(response.headers.get(HttpResponseHeader.CONTENT_TYPE)).toBe(ContentTypeUtf8.TEXT_PLAIN);
+  });
+
+  test('getContentType() returns correct value after res.html()', () => {
+    const res = createKoriResponse();
+
+    res.html('<h1>Hello</h1>');
+    expect(res.getContentType()).toBe(ContentTypeUtf8.TEXT_HTML);
+
+    const response = res.build();
+    expect(response.headers.get(HttpResponseHeader.CONTENT_TYPE)).toBe(ContentTypeUtf8.TEXT_HTML);
+  });
+
+  test('getHeader() returns correct value for explicitly set headers', () => {
+    const res = createKoriResponse();
+
+    res.setHeader('X-Custom-Header', 'test-value');
+    expect(res.getHeader('X-Custom-Header')).toBe('test-value');
+
+    const response = res.build();
+    expect(response.headers.get('X-Custom-Header')).toBe('test-value');
+  });
+
+  test('getHeader() returns correct value for Content-Type after body methods', () => {
+    const res = createKoriResponse();
+
+    res.json({ data: 'test' });
+    expect(res.getHeader(HttpResponseHeader.CONTENT_TYPE)).toBe(ContentTypeUtf8.APPLICATION_JSON);
+
+    const response = res.build();
+    expect(response.headers.get(HttpResponseHeader.CONTENT_TYPE)).toBe(ContentTypeUtf8.APPLICATION_JSON);
+  });
+
+  test('getContentType() returns explicitly set Content-Type over default', () => {
+    const res = createKoriResponse();
+
+    res.json({ data: 'test' });
+    res.setHeader(HttpResponseHeader.CONTENT_TYPE, 'application/vnd.api+json');
+
+    expect(res.getContentType()).toBe('application/vnd.api+json');
+
+    const response = res.build();
+    expect(response.headers.get(HttpResponseHeader.CONTENT_TYPE)).toBe('application/vnd.api+json');
+  });
+
+  test('getContentType() returns undefined for empty responses', () => {
+    const res = createKoriResponse();
+
+    res.empty();
+    expect(res.getContentType()).toBeUndefined();
+
+    const response = res.build();
+    expect(response.headers.get(HttpResponseHeader.CONTENT_TYPE)).toBeNull();
+  });
+});

--- a/packages/kori/tests/context/response-status.test.ts
+++ b/packages/kori/tests/context/response-status.test.ts
@@ -1,0 +1,64 @@
+import { describe, test, expect } from 'vitest';
+
+import { createKoriResponse } from '../../src/context/response.js';
+import { HttpStatus } from '../../src/http/index.js';
+
+describe('KoriResponse status code handling', () => {
+  test('uninitialized response returns 200 OK by default', () => {
+    const res = createKoriResponse();
+
+    // No body method called - should default to 200 OK
+    const response = res.build();
+    expect(response.status).toBe(HttpStatus.OK);
+  });
+
+  test('explicit empty() call returns 204 No Content', () => {
+    const res = createKoriResponse();
+
+    res.empty();
+    const response = res.build();
+    expect(response.status).toBe(HttpStatus.NO_CONTENT);
+  });
+
+  test('json response returns 200 OK by default', () => {
+    const res = createKoriResponse();
+
+    res.json({ message: 'test' });
+    const response = res.build();
+    expect(response.status).toBe(HttpStatus.OK);
+  });
+
+  test('text response returns 200 OK by default', () => {
+    const res = createKoriResponse();
+
+    res.text('Hello World');
+    const response = res.build();
+    expect(response.status).toBe(HttpStatus.OK);
+  });
+
+  test('html response returns 200 OK by default', () => {
+    const res = createKoriResponse();
+
+    res.html('<h1>Hello</h1>');
+    const response = res.build();
+    expect(response.status).toBe(HttpStatus.OK);
+  });
+
+  test('explicit status code overrides default behavior', () => {
+    const res = createKoriResponse();
+
+    // Set explicit status code before empty()
+    res.status(HttpStatus.ACCEPTED).empty();
+    const response = res.build();
+    expect(response.status).toBe(HttpStatus.ACCEPTED);
+  });
+
+  test('explicit status code overrides default for uninitialized response', () => {
+    const res = createKoriResponse();
+
+    // Set explicit status code without calling any body method
+    res.status(HttpStatus.NOT_FOUND);
+    const response = res.build();
+    expect(response.status).toBe(HttpStatus.NOT_FOUND);
+  });
+});

--- a/packages/kori/tests/placeholder.test.ts
+++ b/packages/kori/tests/placeholder.test.ts
@@ -1,7 +1,0 @@
-import { describe, it, expect } from 'vitest';
-
-describe('placeholder test', () => {
-  it('should pass', () => {
-    expect(true).toBe(true);
-  });
-});

--- a/packages/security-headers-plugin/src/security-headers-plugin.ts
+++ b/packages/security-headers-plugin/src/security-headers-plugin.ts
@@ -4,6 +4,7 @@ import {
   type KoriResponse,
   type KoriRequest,
   type KoriEnvironment,
+  HttpResponseHeader,
 } from '@korix/kori';
 
 import { PLUGIN_VERSION } from './version.js';
@@ -139,26 +140,26 @@ function setSecurityHeaders(res: KoriResponse, options: SecurityHeadersOptions):
   const finalOptions = { ...DEFAULT_OPTIONS, ...options };
 
   if (finalOptions.contentTypeOptions !== false) {
-    res.setHeader('x-content-type-options', finalOptions.contentTypeOptions);
+    res.setHeader(HttpResponseHeader.X_CONTENT_TYPE_OPTIONS, finalOptions.contentTypeOptions);
   }
 
   if (finalOptions.xssProtection) {
     // This header is deprecated, but it's important to set it to '0'
     // to disable the browser's built-in XSS auditor in older browsers,
     // which can introduce XSS vulnerabilities.
-    res.setHeader('x-xss-protection', '0');
+    res.setHeader(HttpResponseHeader.X_XSS_PROTECTION, '0');
   }
 
   if (finalOptions.frameOptions !== false) {
-    res.setHeader('x-frame-options', finalOptions.frameOptions);
+    res.setHeader(HttpResponseHeader.X_FRAME_OPTIONS, finalOptions.frameOptions);
   }
 
   if (finalOptions.strictTransportSecurity !== false) {
-    res.setHeader('strict-transport-security', finalOptions.strictTransportSecurity);
+    res.setHeader(HttpResponseHeader.STRICT_TRANSPORT_SECURITY, finalOptions.strictTransportSecurity);
   }
 
   if (finalOptions.referrerPolicy !== false) {
-    res.setHeader('referrer-policy', finalOptions.referrerPolicy);
+    res.setHeader(HttpResponseHeader.REFERRER_POLICY, finalOptions.referrerPolicy);
   }
 
   if (finalOptions.contentSecurityPolicy !== false) {
@@ -169,27 +170,27 @@ function setSecurityHeaders(res: KoriResponse, options: SecurityHeadersOptions):
     } else {
       cspString = buildCspString(finalOptions.contentSecurityPolicy);
     }
-    res.setHeader('content-security-policy', cspString);
+    res.setHeader(HttpResponseHeader.CONTENT_SECURITY_POLICY, cspString);
   }
 
   if (finalOptions.permittedCrossDomainPolicies !== false) {
-    res.setHeader('x-permitted-cross-domain-policies', finalOptions.permittedCrossDomainPolicies);
+    res.setHeader(HttpResponseHeader.X_PERMITTED_CROSS_DOMAIN_POLICIES, finalOptions.permittedCrossDomainPolicies);
   }
 
   if (finalOptions.downloadOptions !== false) {
-    res.setHeader('x-download-options', finalOptions.downloadOptions);
+    res.setHeader(HttpResponseHeader.X_DOWNLOAD_OPTIONS, finalOptions.downloadOptions);
   }
 
   if (finalOptions.crossOriginEmbedderPolicy !== false) {
-    res.setHeader('cross-origin-embedder-policy', finalOptions.crossOriginEmbedderPolicy);
+    res.setHeader(HttpResponseHeader.CROSS_ORIGIN_EMBEDDER_POLICY, finalOptions.crossOriginEmbedderPolicy);
   }
 
   if (finalOptions.crossOriginOpenerPolicy !== false) {
-    res.setHeader('cross-origin-opener-policy', finalOptions.crossOriginOpenerPolicy);
+    res.setHeader(HttpResponseHeader.CROSS_ORIGIN_OPENER_POLICY, finalOptions.crossOriginOpenerPolicy);
   }
 
   if (finalOptions.crossOriginResourcePolicy !== false) {
-    res.setHeader('cross-origin-resource-policy', finalOptions.crossOriginResourcePolicy);
+    res.setHeader(HttpResponseHeader.CROSS_ORIGIN_RESOURCE_POLICY, finalOptions.crossOriginResourcePolicy);
   }
 
   if (options.customHeaders) {

--- a/packages/static-file-plugin-nodejs/README.md
+++ b/packages/static-file-plugin-nodejs/README.md
@@ -135,7 +135,7 @@ staticFilePlugin({
 
 The plugin handles URL-to-file mapping as follows:
 
-```
+```text
 URL: /static/admin/dashboard.html
 Source: ./public
 Result: ./public/admin/dashboard.html
@@ -175,7 +175,7 @@ Automatic content-type detection for common file types:
 
 The plugin prevents directory traversal attacks:
 
-```typescript
+```text
 // These requests are blocked with 404 Not Found
 GET /static/../../../etc/passwd
 GET /static/%2e%2e%2f%2e%2e%2fetc%2fpasswd

--- a/packages/static-file-plugin-nodejs/README.md
+++ b/packages/static-file-plugin-nodejs/README.md
@@ -30,8 +30,8 @@ import { staticFilePlugin } from '@korix/static-file-plugin-nodejs';
 
 const app = createKori().applyPlugin(
   staticFilePlugin({
-    root: './public',
-    prefix: '/static',
+    serveFrom: './public',
+    mountAt: '/static',
   }),
 );
 
@@ -45,8 +45,8 @@ const app = createKori().applyPlugin(
 
 ```typescript
 type StaticFileOptions = {
-  root: string; // Required: Root directory path
-  prefix?: string; // URL prefix (default: '/static')
+  serveFrom: string; // Required: Source directory path
+  mountAt?: string; // URL prefix (default: '/static')
   index?: string[] | false; // Index files (default: ['index.html'])
   dotfiles?: 'allow' | 'deny'; // Dotfiles handling (default: 'deny')
   maxAge?: number; // Cache max-age in seconds (default: 0)
@@ -59,7 +59,7 @@ type StaticFileOptions = {
 
 ```typescript
 {
-  prefix: '/static',
+  mountAt: '/static',
   index: ['index.html'],
   dotfiles: 'deny',
   maxAge: 0,
@@ -78,7 +78,7 @@ import { staticFilePlugin } from '@korix/static-file-plugin-nodejs';
 
 const app = createKori().applyPlugin(
   staticFilePlugin({
-    root: './public',
+    serveFrom: './public',
   }),
 );
 
@@ -90,8 +90,8 @@ const app = createKori().applyPlugin(
 ```typescript
 const app = createKori().applyPlugin(
   staticFilePlugin({
-    root: './assets',
-    prefix: '/assets',
+    serveFrom: './assets',
+    mountAt: '/assets',
     maxAge: 3600, // 1 hour cache
     etag: true,
     lastModified: true,
@@ -107,7 +107,7 @@ const app = createKori().applyPlugin(
 ```typescript
 const app = createKori().applyPlugin(
   staticFilePlugin({
-    root: './public',
+    serveFrom: './public',
     index: ['index.html', 'index.htm', 'default.html'],
   }),
 );
@@ -120,13 +120,13 @@ const app = createKori().applyPlugin(
 ```typescript
 // Deny dotfiles (default)
 staticFilePlugin({
-  root: './public',
+  serveFrom: './public',
   dotfiles: 'deny', // .env, .git/ → 404 Not Found
 });
 
 // Allow dotfiles
 staticFilePlugin({
-  root: './public',
+  serveFrom: './public',
   dotfiles: 'allow', // .env, .git/ → served normally
 });
 ```
@@ -137,16 +137,16 @@ The plugin handles URL-to-file mapping as follows:
 
 ```
 URL: /static/admin/dashboard.html
-Root: ./public
+Source: ./public
 Result: ./public/admin/dashboard.html
 
 URL: /static/admin/
-Root: ./public
+Source: ./public
 Index: ['index.html']
 Result: ./public/admin/index.html (if exists)
 
 URL: /static/
-Root: ./public
+Source: ./public
 Index: ['index.html']
 Result: ./public/index.html (if exists)
 ```
@@ -191,7 +191,7 @@ Control access to dotfiles (files/directories starting with `.`):
 
 ### Safe Path Resolution
 
-All paths are resolved and validated to ensure they remain within the configured root directory.
+All paths are resolved and validated to ensure they remain within the configured source directory.
 
 ## Caching
 
@@ -199,7 +199,7 @@ All paths are resolved and validated to ensure they remain within the configured
 
 ```typescript
 staticFilePlugin({
-  root: './public',
+  serveFrom: './public',
   maxAge: 3600, // Cache-Control: public, max-age=3600
   etag: true, // ETag: "1234567890abcdef"
   lastModified: true, // Last-Modified: Wed, 21 Oct 2015 07:28:00 GMT
@@ -269,7 +269,7 @@ const app = createKori()
   .applyPlugin(securityHeadersPlugin())
   .applyPlugin(
     staticFilePlugin({
-      root: './public',
+      serveFrom: './public',
       maxAge: 3600,
     }),
   )

--- a/packages/static-file-plugin-nodejs/README.md
+++ b/packages/static-file-plugin-nodejs/README.md
@@ -176,7 +176,7 @@ Automatic content-type detection for common file types:
 The plugin prevents directory traversal attacks:
 
 ```typescript
-// These requests are blocked with 403 Forbidden
+// These requests are blocked with 404 Not Found
 GET /static/../../../etc/passwd
 GET /static/%2e%2e%2f%2e%2e%2fetc%2fpasswd
 GET /static/..%5c..%5cetc%5cpasswd
@@ -225,8 +225,8 @@ The plugin returns appropriate HTTP status codes:
 
 - **200 OK**: File served successfully
 - **304 Not Modified**: Conditional request, content unchanged
-- **403 Forbidden**: Path traversal attempt or denied dotfile
-- **404 Not Found**: File not found or ignored dotfile
+- **403 Forbidden**: Directory listing disabled
+- **404 Not Found**: File not found, path traversal attempt, or denied dotfile
 
 Error responses include JSON body:
 

--- a/packages/static-file-plugin-nodejs/README.md
+++ b/packages/static-file-plugin-nodejs/README.md
@@ -1,0 +1,281 @@
+# @korix/static-file-plugin-nodejs
+
+Static file serving plugin for the Kori framework (Node.js).
+
+## Installation
+
+```bash
+npm install @korix/static-file-plugin-nodejs
+# or
+pnpm add @korix/static-file-plugin-nodejs
+# or
+yarn add @korix/static-file-plugin-nodejs
+```
+
+## Features
+
+- 🚀 **High Performance**: Streaming file responses with efficient Node.js APIs
+- 🔒 **Security First**: Path traversal protection and configurable dotfiles handling
+- 📦 **MIME Type Detection**: Automatic content-type headers for common file types
+- ⚡ **Caching Support**: ETag, Last-Modified, and Cache-Control headers
+- 📁 **Index Files**: Automatic index.html resolution for directories
+- 🎯 **Flexible Configuration**: Customizable prefix, dotfiles policy, and more
+- 🛡️ **Conditional Requests**: 304 Not Modified support for efficient caching
+
+## Quick Start
+
+```typescript
+import { createKori } from '@korix/kori';
+import { staticFilePlugin } from '@korix/static-file-plugin-nodejs';
+
+const app = createKori().applyPlugin(
+  staticFilePlugin({
+    root: './public',
+    prefix: '/static',
+  }),
+);
+
+// Files in ./public/ are now accessible at /static/*
+// e.g., ./public/style.css → http://localhost/static/style.css
+```
+
+## Configuration
+
+### Basic Options
+
+```typescript
+type StaticFileOptions = {
+  root: string; // Required: Root directory path
+  prefix?: string; // URL prefix (default: '/static')
+  index?: string[] | false; // Index files (default: ['index.html'])
+  dotfiles?: 'allow' | 'deny'; // Dotfiles handling (default: 'deny')
+  maxAge?: number; // Cache max-age in seconds (default: 0)
+  etag?: boolean; // ETag header (default: true)
+  lastModified?: boolean; // Last-Modified header (default: true)
+};
+```
+
+### Default Configuration
+
+```typescript
+{
+  prefix: '/static',
+  index: ['index.html'],
+  dotfiles: 'deny',
+  maxAge: 0,
+  etag: true,
+  lastModified: true
+}
+```
+
+## Usage Examples
+
+### Basic Static File Serving
+
+```typescript
+import { createKori } from '@korix/kori';
+import { staticFilePlugin } from '@korix/static-file-plugin-nodejs';
+
+const app = createKori().applyPlugin(
+  staticFilePlugin({
+    root: './public',
+  }),
+);
+
+// Serves files from ./public/ at /static/*
+```
+
+### Custom Prefix and Caching
+
+```typescript
+const app = createKori().applyPlugin(
+  staticFilePlugin({
+    root: './assets',
+    prefix: '/assets',
+    maxAge: 3600, // 1 hour cache
+    etag: true,
+    lastModified: true,
+  }),
+);
+
+// Serves files from ./assets/ at /assets/*
+// With 1-hour caching and ETag support
+```
+
+### Multiple Index Files
+
+```typescript
+const app = createKori().applyPlugin(
+  staticFilePlugin({
+    root: './public',
+    index: ['index.html', 'index.htm', 'default.html'],
+  }),
+);
+
+// Tries index files in order when accessing directories
+```
+
+### Dotfiles Configuration
+
+```typescript
+// Deny dotfiles (default)
+staticFilePlugin({
+  root: './public',
+  dotfiles: 'deny', // .env, .git/ → 404 Not Found
+});
+
+// Allow dotfiles
+staticFilePlugin({
+  root: './public',
+  dotfiles: 'allow', // .env, .git/ → served normally
+});
+```
+
+## Path Resolution
+
+The plugin handles URL-to-file mapping as follows:
+
+```
+URL: /static/admin/dashboard.html
+Root: ./public
+Result: ./public/admin/dashboard.html
+
+URL: /static/admin/
+Root: ./public
+Index: ['index.html']
+Result: ./public/admin/index.html (if exists)
+
+URL: /static/
+Root: ./public
+Index: ['index.html']
+Result: ./public/index.html (if exists)
+```
+
+## MIME Types
+
+Automatic content-type detection for common file types:
+
+| Extension         | MIME Type                  |
+| ----------------- | -------------------------- |
+| `.html`, `.htm`   | `text/html`                |
+| `.css`            | `text/css`                 |
+| `.js`, `.mjs`     | `text/javascript`          |
+| `.png`            | `image/png`                |
+| `.jpg`, `.jpeg`   | `image/jpeg`               |
+| `.gif`            | `image/gif`                |
+| `.svg`            | `image/svg+xml`            |
+| `.woff`, `.woff2` | `font/woff`, `font/woff2`  |
+| `.pdf`            | `application/pdf`          |
+| `.json`           | `application/json`         |
+| (others)          | `application/octet-stream` |
+
+## Security Features
+
+### Path Traversal Protection
+
+The plugin prevents directory traversal attacks:
+
+```typescript
+// These requests are blocked with 403 Forbidden
+GET /static/../../../etc/passwd
+GET /static/%2e%2e%2f%2e%2e%2fetc%2fpasswd
+GET /static/..%5c..%5cetc%5cpasswd
+```
+
+### Dotfiles Handling
+
+Control access to dotfiles (files/directories starting with `.`):
+
+- **`deny`** (default): Return 404 Not Found
+- **`allow`**: Serve normally
+
+### Safe Path Resolution
+
+All paths are resolved and validated to ensure they remain within the configured root directory.
+
+## Caching
+
+### HTTP Cache Headers
+
+```typescript
+staticFilePlugin({
+  root: './public',
+  maxAge: 3600, // Cache-Control: public, max-age=3600
+  etag: true, // ETag: "1234567890abcdef"
+  lastModified: true, // Last-Modified: Wed, 21 Oct 2015 07:28:00 GMT
+});
+```
+
+### Conditional Requests
+
+Supports `If-None-Match` header for efficient caching:
+
+```http
+GET /static/style.css
+ETag: "abc123"
+
+GET /static/style.css
+If-None-Match: "abc123"
+→ 304 Not Modified (empty body)
+```
+
+## Error Handling
+
+The plugin returns appropriate HTTP status codes:
+
+- **200 OK**: File served successfully
+- **304 Not Modified**: Conditional request, content unchanged
+- **403 Forbidden**: Path traversal attempt or denied dotfile
+- **404 Not Found**: File not found or ignored dotfile
+
+Error responses include JSON body:
+
+```json
+{
+  "error": "Not Found",
+  "message": "File not found"
+}
+```
+
+## Performance Notes
+
+- **Streaming**: Files are streamed directly without buffering
+- **ETag Generation**: Based on file modification time and size (fast)
+- **Path Validation**: Optimized for security without performance penalty
+- **MIME Detection**: Efficient extension-based lookup
+
+## Node.js Compatibility
+
+- **Node.js**: >= 18.0.0
+- **File System**: Uses `node:fs/promises` and streaming APIs
+- **Path Handling**: Uses `node:path` for cross-platform compatibility
+
+## Integration with Other Middleware
+
+The static file plugin works well with other Kori plugins:
+
+```typescript
+import { createKori } from '@korix/kori';
+import { corsPlugin } from '@korix/cors-plugin';
+import { securityHeadersPlugin } from '@korix/security-headers-plugin';
+import { staticFilePlugin } from '@korix/static-file-plugin-nodejs';
+
+const app = createKori()
+  .applyPlugin(
+    corsPlugin({
+      origin: true,
+    }),
+  )
+  .applyPlugin(securityHeadersPlugin())
+  .applyPlugin(
+    staticFilePlugin({
+      root: './public',
+      maxAge: 3600,
+    }),
+  )
+  .get('/api/health', (ctx) => ctx.res.json({ status: 'ok' }));
+```
+
+## License
+
+MIT

--- a/packages/static-file-plugin-nodejs/eslint.config.js
+++ b/packages/static-file-plugin-nodejs/eslint.config.js
@@ -1,0 +1,17 @@
+import { koriConfig } from '@korix/eslint-config';
+
+export default [
+  ...koriConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: './tsconfig.json',
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      // Allow Node.js modules in this Node.js-specific plugin
+      'import-x/no-nodejs-modules': 'off',
+    },
+  },
+];

--- a/packages/static-file-plugin-nodejs/package.json
+++ b/packages/static-file-plugin-nodejs/package.json
@@ -1,0 +1,72 @@
+{
+  "name": "@korix/static-file-plugin-nodejs",
+  "version": "0.1.0",
+  "description": "Static file serving plugin for Kori framework (Node.js)",
+  "type": "module",
+  "author": "mitz (@bufferings)",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bufferings/kori"
+  },
+  "homepage": "https://github.com/bufferings/kori",
+  "bugs": "https://github.com/bufferings/kori/issues",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "import": {
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        },
+        "require": {
+          "types": "./dist/index.d.cts",
+          "default": "./dist/index.cjs"
+        }
+      }
+    }
+  },
+  "exports": {
+    ".": {
+      "development": "./src/index.ts",
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "scripts": {
+    "clean": "rimraf dist *.tsbuildinfo .turbo .tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "build": "tsdown --tsconfig tsconfig.build.json",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "sync:version": "ks sync-version && prettier --write src/version.ts"
+  },
+  "peerDependencies": {
+    "@korix/kori": "workspace:*"
+  },
+  "devDependencies": {
+    "@korix/eslint-config": "workspace:*",
+    "@korix/kori": "workspace:*",
+    "@korix/script": "workspace:*",
+    "@types/node": "catalog:",
+    "eslint": "catalog:",
+    "rimraf": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/static-file-plugin-nodejs/src/file-utils.ts
+++ b/packages/static-file-plugin-nodejs/src/file-utils.ts
@@ -1,0 +1,152 @@
+import { createHash } from 'node:crypto';
+import { createReadStream } from 'node:fs';
+import { type Stats } from 'node:fs';
+import { access, stat as statAsync } from 'node:fs/promises';
+import { resolve, normalize, join, sep, relative } from 'node:path';
+
+import { type KoriLogger } from '@korix/kori';
+
+import { type StaticFileOptions } from './static-file-options.js';
+
+export type FileInfo = {
+  path: string;
+  stats: Stats;
+  exists: boolean;
+};
+
+export type ResolvedPath = {
+  safePath: string;
+  isValid: boolean;
+  isDotfile: boolean;
+};
+
+/**
+ * Safely resolve a file path within the root directory
+ * Prevents directory traversal attacks
+ */
+export function resolveSafePath(requestPath: string, rootDir: string): ResolvedPath {
+  try {
+    // Remove query string and hash
+    const cleanPath = requestPath.split('?')[0]?.split('#')[0] ?? '';
+
+    // Normalize and resolve paths
+    const normalizedPath = normalize(cleanPath);
+    const resolvedRoot = resolve(rootDir);
+    const resolvedPath = resolve(resolvedRoot, normalizedPath.slice(1)); // Remove leading slash
+
+    // Check if resolved path is within root directory
+    const relativePath = relative(resolvedRoot, resolvedPath);
+    const isValid = !relativePath.startsWith('..') && !relativePath.startsWith('/');
+
+    // Check if it's a dotfile
+    const isDotfile = normalizedPath.split(sep).some((segment) => segment.startsWith('.'));
+
+    return {
+      safePath: resolvedPath,
+      isValid,
+      isDotfile,
+    };
+  } catch {
+    return {
+      safePath: '',
+      isValid: false,
+      isDotfile: false,
+    };
+  }
+}
+
+/**
+ * Check if a file exists and get its stats
+ */
+export async function getFileInfo(filePath: string): Promise<FileInfo> {
+  try {
+    await access(filePath);
+    const stats = await statAsync(filePath);
+    return {
+      path: filePath,
+      stats,
+      exists: true,
+    };
+  } catch {
+    return {
+      path: filePath,
+      stats: {} as Stats,
+      exists: false,
+    };
+  }
+}
+
+/**
+ * Try to resolve index files for directory requests
+ */
+export async function resolveIndexFile(
+  dirPath: string,
+  indexFiles: string[],
+  log: KoriLogger,
+): Promise<FileInfo | null> {
+  for (const indexFile of indexFiles) {
+    const indexPath = join(dirPath, indexFile);
+    const fileInfo = await getFileInfo(indexPath);
+
+    if (fileInfo.exists && fileInfo.stats.isFile()) {
+      log.debug('Resolved index file', { dirPath, indexFile, indexPath });
+      return fileInfo;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Check if dotfile access is allowed based on configuration
+ */
+export function isDotfileAllowed(isDotfile: boolean, dotfiles: NonNullable<StaticFileOptions['dotfiles']>): boolean {
+  if (!isDotfile) {
+    return true;
+  }
+
+  return dotfiles === 'allow';
+}
+
+/**
+ * Generate ETag based on file stats (mtime + size)
+ */
+export function generateETag(stats: Stats): string {
+  const hash = createHash('md5');
+  hash.update(`${stats.mtime.getTime()}-${stats.size}`);
+  return `"${hash.digest('hex')}"`;
+}
+
+/**
+ * Format Last-Modified header value
+ */
+export function formatLastModified(mtime: Date): string {
+  return mtime.toUTCString();
+}
+
+/**
+ * Create a readable stream for file content (Web Streams API)
+ */
+export function createFileStream(filePath: string): ReadableStream {
+  const nodeStream = createReadStream(filePath);
+
+  return new ReadableStream({
+    start(controller) {
+      nodeStream.on('data', (chunk: Buffer) => {
+        controller.enqueue(new Uint8Array(chunk));
+      });
+
+      nodeStream.on('end', () => {
+        controller.close();
+      });
+
+      nodeStream.on('error', (error) => {
+        controller.error(error);
+      });
+    },
+
+    cancel() {
+      nodeStream.destroy();
+    },
+  });
+}

--- a/packages/static-file-plugin-nodejs/src/file-utils.ts
+++ b/packages/static-file-plugin-nodejs/src/file-utils.ts
@@ -8,11 +8,18 @@ import { type KoriLogger } from '@korix/kori';
 
 import { type StaticFileOptions } from './static-file-options.js';
 
-export type FileInfo = {
+export type ExistingFileInfo = {
+  exists: true;
   path: string;
   stats: Stats;
-  exists: boolean;
 };
+
+export type NonExistentFileInfo = {
+  exists: false;
+  path: string;
+};
+
+export type FileInfo = ExistingFileInfo | NonExistentFileInfo;
 
 export type ResolvedPath = {
   safePath: string;
@@ -72,7 +79,6 @@ export async function getFileInfo(filePath: string): Promise<FileInfo> {
   } catch {
     return {
       path: filePath,
-      stats: {} as Stats,
       exists: false,
     };
   }
@@ -85,7 +91,7 @@ export async function resolveIndexFile(
   dirPath: string,
   indexFiles: string[],
   log: KoriLogger,
-): Promise<FileInfo | null> {
+): Promise<ExistingFileInfo | null> {
   for (const indexFile of indexFiles) {
     const indexPath = join(dirPath, indexFile);
     const fileInfo = await getFileInfo(indexPath);

--- a/packages/static-file-plugin-nodejs/src/file-utils.ts
+++ b/packages/static-file-plugin-nodejs/src/file-utils.ts
@@ -32,7 +32,9 @@ export function resolveSafePath(requestPath: string, rootDir: string): ResolvedP
     // Normalize and resolve paths
     const normalizedPath = normalize(cleanPath);
     const resolvedRoot = resolve(rootDir);
-    const resolvedPath = resolve(resolvedRoot, normalizedPath.slice(1)); // Remove leading slash
+    // Remove leading slash if present
+    const pathWithoutLeadingSlash = normalizedPath.replace(/^\//, '');
+    const resolvedPath = resolve(resolvedRoot, pathWithoutLeadingSlash);
 
     // Check if resolved path is within root directory
     const relativePath = relative(resolvedRoot, resolvedPath);

--- a/packages/static-file-plugin-nodejs/src/index.ts
+++ b/packages/static-file-plugin-nodejs/src/index.ts
@@ -1,0 +1,2 @@
+export { type StaticFileOptions } from './static-file-options.js';
+export { staticFilePlugin } from './static-file-plugin.js';

--- a/packages/static-file-plugin-nodejs/src/mime-types.ts
+++ b/packages/static-file-plugin-nodejs/src/mime-types.ts
@@ -1,0 +1,69 @@
+/**
+ * MIME type mappings for common file extensions
+ */
+const MIME_TYPES: Record<string, string> = {
+  // HTML
+  '.html': 'text/html',
+  '.htm': 'text/html',
+
+  // CSS
+  '.css': 'text/css',
+
+  // JavaScript
+  '.js': 'text/javascript',
+  '.mjs': 'text/javascript',
+
+  // Images
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon',
+  '.webp': 'image/webp',
+  '.avif': 'image/avif',
+
+  // Fonts
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.ttf': 'font/ttf',
+  '.eot': 'application/vnd.ms-fontobject',
+  '.otf': 'font/otf',
+
+  // Documents
+  '.pdf': 'application/pdf',
+  '.txt': 'text/plain',
+  '.json': 'application/json',
+  '.xml': 'application/xml',
+  '.csv': 'text/csv',
+
+  // Media
+  '.mp4': 'video/mp4',
+  '.webm': 'video/webm',
+  '.mp3': 'audio/mpeg',
+  '.wav': 'audio/wav',
+  '.ogg': 'audio/ogg',
+
+  // Archives
+  '.zip': 'application/zip',
+  '.tar': 'application/x-tar',
+  '.gz': 'application/gzip',
+
+  // Other
+  '.wasm': 'application/wasm',
+} as const;
+
+const DEFAULT_MIME_TYPE = 'application/octet-stream';
+
+/**
+ * Detect MIME type based on file extension
+ */
+export function detectMimeType(filePath: string): string {
+  const lastDotIndex = filePath.lastIndexOf('.');
+  if (lastDotIndex === -1) {
+    return DEFAULT_MIME_TYPE;
+  }
+
+  const extension = filePath.slice(lastDotIndex).toLowerCase();
+  return MIME_TYPES[extension] ?? DEFAULT_MIME_TYPE;
+}

--- a/packages/static-file-plugin-nodejs/src/static-file-options.ts
+++ b/packages/static-file-plugin-nodejs/src/static-file-options.ts
@@ -1,9 +1,9 @@
 export type StaticFileOptions = {
-  /** Required: Root directory path for serving static files */
-  root: string;
+  /** Required: Source directory path to serve static files from */
+  serveFrom: string;
 
   /** URL prefix for static files (default: '/static') */
-  prefix?: string;
+  mountAt?: string;
 
   /** Index files to serve when accessing directories (default: ['index.html']) */
   index?: string[] | false;

--- a/packages/static-file-plugin-nodejs/src/static-file-options.ts
+++ b/packages/static-file-plugin-nodejs/src/static-file-options.ts
@@ -1,0 +1,22 @@
+export type StaticFileOptions = {
+  /** Required: Root directory path for serving static files */
+  root: string;
+
+  /** URL prefix for static files (default: '/static') */
+  prefix?: string;
+
+  /** Index files to serve when accessing directories (default: ['index.html']) */
+  index?: string[] | false;
+
+  /** Dotfiles handling (default: 'deny') */
+  dotfiles?: 'allow' | 'deny';
+
+  /** Cache max-age in seconds (default: 0) */
+  maxAge?: number;
+
+  /** ETag header generation (default: true) */
+  etag?: boolean;
+
+  /** Last-Modified header generation (default: true) */
+  lastModified?: boolean;
+};

--- a/packages/static-file-plugin-nodejs/src/static-file-plugin.ts
+++ b/packages/static-file-plugin-nodejs/src/static-file-plugin.ts
@@ -119,8 +119,7 @@ function serveFile(
   });
 
   const fileStream = createFileStream(fileInfo.path);
-  res.status(HttpStatus.OK).stream(fileStream);
-  return res;
+  return res.stream(fileStream, HttpStatus.OK);
 }
 
 async function handleStaticFileRequest(
@@ -134,56 +133,74 @@ async function handleStaticFileRequest(
 
   if (!resolvedPath.isValid) {
     log.warn('Invalid file path detected', { requestPath, resolvedPath: resolvedPath.safePath });
-    return res.status(HttpStatus.FORBIDDEN).json({
-      error: 'Forbidden',
-      message: 'Access denied',
-    });
+    return res.json(
+      {
+        error: 'Forbidden',
+        message: 'Access denied',
+      },
+      HttpStatus.FORBIDDEN,
+    );
   }
 
   if (!isDotfileAllowed(resolvedPath.isDotfile, options.dotfiles)) {
     log.debug('Dotfile access denied', { path: resolvedPath.safePath });
-    return res.status(HttpStatus.NOT_FOUND).json({
-      error: 'Not Found',
-      message: 'File not found',
-    });
+    return res.json(
+      {
+        error: 'Not Found',
+        message: 'File not found',
+      },
+      HttpStatus.NOT_FOUND,
+    );
   }
 
   let fileInfo = await getFileInfo(resolvedPath.safePath);
 
   if (!fileInfo.exists) {
     log.debug('File not found', { path: resolvedPath.safePath });
-    return res.status(HttpStatus.NOT_FOUND).json({
-      error: 'Not Found',
-      message: 'File not found',
-    });
+    return res.json(
+      {
+        error: 'Not Found',
+        message: 'File not found',
+      },
+      HttpStatus.NOT_FOUND,
+    );
   }
 
   if (fileInfo.stats.isDirectory()) {
     if (options.index === false) {
       log.debug('Directory listing disabled', { path: resolvedPath.safePath });
-      return res.status(HttpStatus.FORBIDDEN).json({
-        error: 'Forbidden',
-        message: 'Directory listing is disabled',
-      });
+      return res.json(
+        {
+          error: 'Forbidden',
+          message: 'Directory listing is disabled',
+        },
+        HttpStatus.FORBIDDEN,
+      );
     }
 
     const indexFile = await resolveIndexFile(resolvedPath.safePath, options.index, log);
     if (!indexFile) {
       log.debug('No index file found in directory', { path: resolvedPath.safePath });
-      return res.status(HttpStatus.NOT_FOUND).json({
-        error: 'Not Found',
-        message: 'No index file found',
-      });
+      return res.json(
+        {
+          error: 'Not Found',
+          message: 'No index file found',
+        },
+        HttpStatus.NOT_FOUND,
+      );
     }
     fileInfo = indexFile;
   }
 
   if (!fileInfo.stats.isFile()) {
     log.debug('Path is not a regular file', { path: fileInfo.path });
-    return res.status(HttpStatus.NOT_FOUND).json({
-      error: 'Not Found',
-      message: 'File not found',
-    });
+    return res.json(
+      {
+        error: 'Not Found',
+        message: 'File not found',
+      },
+      HttpStatus.NOT_FOUND,
+    );
   }
 
   return serveFile(req, res, fileInfo, options, log);

--- a/packages/static-file-plugin-nodejs/src/static-file-plugin.ts
+++ b/packages/static-file-plugin-nodejs/src/static-file-plugin.ts
@@ -64,6 +64,13 @@ function removeMountPrefix(pathname: string, mountAt: string): string {
   if (pathname === mountAt) {
     return '/';
   }
+
+  if (!pathname.startsWith(mountAt)) {
+    throw new Error(
+      `[INTERNAL] Pathname "${pathname}" does not start with mount prefix "${mountAt}". This indicates a routing system bug.`,
+    );
+  }
+
   return pathname.slice(mountAt.length);
 }
 

--- a/packages/static-file-plugin-nodejs/src/static-file-plugin.ts
+++ b/packages/static-file-plugin-nodejs/src/static-file-plugin.ts
@@ -120,7 +120,6 @@ function serveFile(
 
   const fileStream = createFileStream(fileInfo.path);
   res.status(HttpStatus.OK).stream(fileStream);
-  res.setHeader('content-type', mimeType);
   return res;
 }
 

--- a/packages/static-file-plugin-nodejs/src/static-file-plugin.ts
+++ b/packages/static-file-plugin-nodejs/src/static-file-plugin.ts
@@ -17,7 +17,7 @@ import {
   generateETag,
   formatLastModified,
   createFileStream,
-  type FileInfo,
+  type ExistingFileInfo,
 } from './file-utils.js';
 import { detectMimeType } from './mime-types.js';
 import { type StaticFileOptions } from './static-file-options.js';
@@ -69,7 +69,7 @@ function removeMountPrefix(pathname: string, mountAt: string): string {
 
 function setCacheHeaders(
   res: KoriResponse,
-  fileInfo: FileInfo,
+  fileInfo: ExistingFileInfo,
   options: Required<Pick<StaticFileOptions, 'maxAge' | 'etag' | 'lastModified'>>,
 ): void {
   if (options.maxAge > 0) {
@@ -87,7 +87,7 @@ function setCacheHeaders(
   }
 }
 
-function checkConditionalRequest(req: KoriRequest, fileInfo: FileInfo): boolean {
+function checkConditionalRequest(req: KoriRequest, fileInfo: ExistingFileInfo): boolean {
   const ifNoneMatch = req.header('if-none-match');
   if (ifNoneMatch) {
     const etag = generateETag(fileInfo.stats);
@@ -99,7 +99,7 @@ function checkConditionalRequest(req: KoriRequest, fileInfo: FileInfo): boolean 
 function serveFile(
   req: KoriRequest,
   res: KoriResponse,
-  fileInfo: FileInfo,
+  fileInfo: ExistingFileInfo,
   options: Required<Pick<StaticFileOptions, 'maxAge' | 'etag' | 'lastModified'>>,
   log: KoriLogger,
 ): KoriResponse {

--- a/packages/static-file-plugin-nodejs/src/static-file-plugin.ts
+++ b/packages/static-file-plugin-nodejs/src/static-file-plugin.ts
@@ -133,9 +133,9 @@ async function handleStaticFileRequest(
   const resolvedPath = resolveSafePath(requestPath, options.serveFrom);
 
   if (!resolvedPath.isValid) {
-    log.warn('Invalid file path detected', { requestPath, resolvedPath: resolvedPath.safePath });
-    return res.forbidden({
-      message: 'Access denied',
+    log.warn('Invalid file path detected', { requestPath });
+    return res.notFound({
+      message: 'File not found',
     });
   }
 

--- a/packages/static-file-plugin-nodejs/src/version.ts
+++ b/packages/static-file-plugin-nodejs/src/version.ts
@@ -1,0 +1,1 @@
+export const PLUGIN_VERSION = '0.1.0';

--- a/packages/static-file-plugin-nodejs/tests/placeholder.test.ts
+++ b/packages/static-file-plugin-nodejs/tests/placeholder.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest';
+
+describe('placeholder', () => {
+  it('should pass', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/packages/static-file-plugin-nodejs/tests/placeholder.test.ts
+++ b/packages/static-file-plugin-nodejs/tests/placeholder.test.ts
@@ -1,7 +1,0 @@
-import { describe, it, expect } from 'vitest';
-
-describe('placeholder', () => {
-  it('should pass', () => {
-    expect(true).toBe(true);
-  });
-});

--- a/packages/static-file-plugin-nodejs/tests/static-file-plugin.test.ts
+++ b/packages/static-file-plugin-nodejs/tests/static-file-plugin.test.ts
@@ -128,6 +128,44 @@ describe('static-file-plugin-nodejs', () => {
       expect(await response.text()).toBe('<html><body>Index</body></html>');
     });
 
+    it('should serve index.html for mount point without trailing slash', async () => {
+      const app = createKori().applyPlugin(
+        staticFilePlugin({
+          serveFrom: publicDir,
+          mountAt: '/static',
+        }),
+      );
+
+      const response = await fetchFromApp(app, 'http://localhost/static');
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('content-type')).toBe('text/html');
+      expect(await response.text()).toBe('<html><body>Index</body></html>');
+    });
+
+    it('should handle various path patterns correctly', async () => {
+      const app = createKori().applyPlugin(
+        staticFilePlugin({
+          serveFrom: publicDir,
+          mountAt: '/static',
+        }),
+      );
+
+      // Test various path patterns
+      const testCases = [
+        { path: 'http://localhost/static', expectedStatus: 200 },
+        { path: 'http://localhost/static/', expectedStatus: 200 },
+        { path: 'http://localhost/static/index.html', expectedStatus: 200 },
+        { path: 'http://localhost/static/admin', expectedStatus: 200 },
+        { path: 'http://localhost/static/admin/', expectedStatus: 200 },
+      ];
+
+      for (const { path, expectedStatus } of testCases) {
+        const response = await fetchFromApp(app, path);
+        expect(response.status).toBe(expectedStatus);
+      }
+    });
+
     it('should serve index.html for subdirectory requests', async () => {
       const app = createKori().applyPlugin(
         staticFilePlugin({

--- a/packages/static-file-plugin-nodejs/tests/static-file-plugin.test.ts
+++ b/packages/static-file-plugin-nodejs/tests/static-file-plugin.test.ts
@@ -91,8 +91,10 @@ describe('static-file-plugin-nodejs', () => {
 
       expect(response.status).toBe(404);
       expect(await response.json()).toEqual({
-        error: 'Not Found',
-        message: 'File not found',
+        error: {
+          type: 'NOT_FOUND',
+          message: 'File not found',
+        },
       });
     });
 
@@ -167,8 +169,10 @@ describe('static-file-plugin-nodejs', () => {
 
       expect(response.status).toBe(403);
       expect(await response.json()).toEqual({
-        error: 'Forbidden',
-        message: 'Directory listing is disabled',
+        error: {
+          type: 'FORBIDDEN',
+          message: 'Directory listing is disabled',
+        },
       });
     });
   });
@@ -200,8 +204,10 @@ describe('static-file-plugin-nodejs', () => {
 
       expect(response.status).toBe(404);
       expect(await response.json()).toEqual({
-        error: 'Not Found',
-        message: 'File not found',
+        error: {
+          type: 'NOT_FOUND',
+          message: 'File not found',
+        },
       });
     });
 

--- a/packages/static-file-plugin-nodejs/tsconfig.build.json
+++ b/packages/static-file-plugin-nodejs/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"],
+  "references": [{ "path": "../kori" }]
+}

--- a/packages/static-file-plugin-nodejs/tsconfig.json
+++ b/packages/static-file-plugin-nodejs/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.dev.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "references": [{ "path": "../kori" }]
+}

--- a/packages/static-file-plugin-nodejs/tsdown.config.js
+++ b/packages/static-file-plugin-nodejs/tsdown.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  clean: false,
+  sourcemap: true,
+  external: ['@korix/kori', 'node:fs', 'node:fs/promises', 'node:path', 'node:crypto'],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -467,6 +467,36 @@ importers:
         specifier: 'catalog:'
         version: 2.1.9(@types/node@20.11.17)
 
+  packages/static-file-plugin-nodejs:
+    devDependencies:
+      '@korix/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@korix/kori':
+        specifier: workspace:*
+        version: link:../kori
+      '@korix/script':
+        specifier: workspace:*
+        version: link:../script
+      '@types/node':
+        specifier: 'catalog:'
+        version: 20.11.17
+      eslint:
+        specifier: 'catalog:'
+        version: 9.16.0(jiti@2.4.2)
+      rimraf:
+        specifier: 'catalog:'
+        version: 6.0.1
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.12.9(typescript@5.8.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.8.3
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.9(@types/node@20.11.17)
+
   packages/zod-openapi-plugin:
     devDependencies:
       '@korix/eslint-config':

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,9 @@
     { "path": "./packages/openapi-plugin" },
     { "path": "./packages/openapi-scalar-ui-plugin" },
     { "path": "./packages/pino-adapter" },
+    { "path": "./packages/script" },
     { "path": "./packages/security-headers-plugin" },
+    { "path": "./packages/static-file-plugin-nodejs" },
     { "path": "./packages/zod-openapi-plugin" },
     { "path": "./packages/zod-schema" },
     { "path": "./packages/zod-validator" }


### PR DESCRIPTION
## Summary

Adds a new `@korix/static-file-plugin-nodejs` package for secure static file serving with an intuitive API.

## Features

- 🔒 **Security**: Path traversal protection and configurable dotfiles handling
- ⚡ **Performance**: Streaming file delivery with efficient caching headers
- 📦 **MIME Detection**: Automatic content-type headers for common file types
- 🎯 **Intuitive API**: Clear `serveFrom`/`mountAt` options for easy configuration
- ✅ **Quality**: Comprehensive test coverage (19 tests) and full TypeScript support

## Configuration Options

- `serveFrom`: Required source directory path to serve files from
- `mountAt`: URL prefix for static files (default: '/static')
- `index`: Index files for directories (default: ['index.html'])
- `dotfiles`: Dotfile handling - 'allow' or 'deny' (default: 'deny')
- `maxAge`: Cache max-age in seconds (default: 0)
- `etag`: ETag header generation (default: true)
- `lastModified`: Last-Modified header generation (default: true)

## Usage Example

```typescript
import { createKori } from '@korix/kori';
import { staticFilePlugin } from '@korix/static-file-plugin-nodejs';

const app = createKori().applyPlugin(
  staticFilePlugin({
    serveFrom: './public', // Source directory
    mountAt: '/static', // URL prefix
    maxAge: 3600, // 1 hour cache
  }),
);
```

## URL Mapping Examples

```
File: ./public/style.css → URL: /static/style.css
File: ./public/js/app.js → URL: /static/js/app.js
File: ./public/index.html → URL: /static/ (as index file)
```

## Implementation Details

- Built with Node.js built-in modules (fs, path, crypto)
- Supports both ESM and CJS builds via tsdown
- Security-first approach with 404 responses for denied access
- Efficient file streaming using Web Streams API
- ETag generation using MD5 hash of file stats
- Modern function naming without underscore prefixes

## Security Features

- **Path Traversal Protection**: Prevents access outside source directory
- **Dotfiles Handling**: Configurable access to hidden files (default: deny with 404)
- **Safe Path Resolution**: Validates all file paths before serving

## Testing

All 19 tests pass, covering:

- Basic file serving and MIME type detection
- Security (path traversal, dotfiles)
- Caching (ETag, conditional requests, Last-Modified)
- Index file resolution
- Error handling and validation
- API option validation

## Monorepo Integration

- ✅ Added to TypeScript project references
- ✅ Configured for Changeset version management
- ✅ Proper external dependencies in build configuration
- ✅ Follows project coding standards and naming conventions

Ready for production use! 🚀


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a static file serving plugin for Node.js with secure path handling, streaming file delivery, MIME type detection, and configurable caching headers.
  * Added options for URL prefix mounting, index file handling, dotfile access control, and cache management.
  * Provided ESLint configuration and build scripts tailored for the plugin.

* **Bug Fixes**
  * Ensured manual Content-Type headers in responses are preserved when setting body content.

* **Tests**
  * Added comprehensive tests covering file serving, index resolution, dotfile policies, caching headers, security against path traversal, and option validation.

* **Documentation**
  * Added detailed README with installation, configuration, usage examples, security considerations, and integration guidance for the static file plugin.

* **Chores**
  * Added TypeScript configuration files and package metadata for the new plugin.
  * Updated monorepo references to include the new package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->