### PR TITLE
feat(static-file-plugin): add HTTP Range Request support

### DIFF
--- a/.changeset/header-constants-standardization.md
+++ b/.changeset/header-constants-standardization.md
@@ -2,7 +2,6 @@
 '@korix/kori': patch
 '@korix/static-file-plugin-nodejs': patch
 '@korix/security-headers-plugin': patch
-'@korix/example': patch
 ---
 
 Standardize HTTP header names using constants

--- a/.changeset/multipart-range-requests.md
+++ b/.changeset/multipart-range-requests.md
@@ -1,0 +1,11 @@
+---
+'@korix/static-file-plugin-nodejs': minor
+---
+
+Add multipart range request support for HTTP 206 Partial Content
+
+- Implement multipart/byteranges response format for multiple ranges
+- Add maxRanges configuration option to limit simultaneous ranges
+- Support industry-standard range request formats (bytes=0-999,5000-5999)
+- Include comprehensive test coverage for multipart scenarios
+- Update documentation with multipart range examples and configuration

--- a/packages/kori/src/http/headers.ts
+++ b/packages/kori/src/http/headers.ts
@@ -30,11 +30,13 @@ export type HttpRequestHeaderName = (typeof HttpRequestHeader)[keyof typeof Http
  */
 export const HttpResponseHeader = {
   ACCESS_CONTROL_ALLOW_ORIGIN: 'access-control-allow-origin',
+  ACCEPT_RANGES: 'accept-ranges',
   CACHE_CONTROL: 'cache-control',
   CONNECTION: 'connection',
   CONTENT_DISPOSITION: 'content-disposition',
   CONTENT_ENCODING: 'content-encoding',
   CONTENT_LENGTH: 'content-length',
+  CONTENT_RANGE: 'content-range',
   CONTENT_SECURITY_POLICY: 'content-security-policy',
   CONTENT_TYPE: 'content-type',
   CROSS_ORIGIN_EMBEDDER_POLICY: 'cross-origin-embedder-policy',

--- a/packages/kori/src/http/status-codes.ts
+++ b/packages/kori/src/http/status-codes.ts
@@ -197,6 +197,12 @@ export const HttpStatus = {
   UNSUPPORTED_MEDIA_TYPE: 415,
 
   /**
+   * **416 Range Not Satisfiable**
+   * The range specified by the Range header field in the request cannot be fulfilled.
+   */
+  RANGE_NOT_SATISFIABLE: 416,
+
+  /**
    * **422 Unprocessable Content**
    * The request was well-formed but was unable to be followed due to semantic errors.
    */

--- a/packages/static-file-plugin-nodejs/src/file-utils.ts
+++ b/packages/static-file-plugin-nodejs/src/file-utils.ts
@@ -6,7 +6,7 @@ import { resolve, normalize, join, sep, relative } from 'node:path';
 
 import { type KoriLogger } from '@korix/kori';
 
-import { type StaticFileOptions } from './static-file-options.js';
+import { type StaticFileOptions, type ParsedRange, type RangeResult } from './static-file-options.js';
 
 export type ExistingFileInfo = {
   exists: true;
@@ -157,4 +157,121 @@ export function createFileStream(filePath: string): ReadableStream {
       nodeStream.destroy();
     },
   });
+}
+
+/**
+ * Parse Range header and return parsed ranges
+ */
+export function parseRangeHeader(rangeHeader: string | undefined, fileSize: number): RangeResult {
+  const ranges: ParsedRange[] = [];
+  let isSatisfiable = true;
+
+  // Check if range header exists and is valid
+  if (!rangeHeader?.startsWith('bytes=')) {
+    return { ranges: [], totalSize: fileSize, isSatisfiable: false };
+  }
+
+  const rangeSpec = rangeHeader.substring(6); // Remove "bytes="
+  const rangeSpecs = rangeSpec.split(',');
+
+  for (const spec of rangeSpecs) {
+    const trimmedSpec = spec.trim();
+    let start: number;
+    let end: number;
+
+    if (trimmedSpec.startsWith('-')) {
+      // Suffix range: -500 (last 500 bytes)
+      const suffixLength = parseInt(trimmedSpec.substring(1), 10);
+      if (isNaN(suffixLength) || suffixLength <= 0) {
+        isSatisfiable = false;
+        continue;
+      }
+      start = Math.max(0, fileSize - suffixLength);
+      end = fileSize - 1;
+    } else if (trimmedSpec.endsWith('-')) {
+      // Start range: 500- (from 500 to end)
+      start = parseInt(trimmedSpec.slice(0, -1), 10);
+      if (isNaN(start) || start < 0) {
+        isSatisfiable = false;
+        continue;
+      }
+      end = fileSize - 1;
+    } else {
+      // Full range: 0-499
+      const parts = trimmedSpec.split('-');
+      if (parts.length !== 2 || !parts[0] || !parts[1]) {
+        isSatisfiable = false;
+        continue;
+      }
+      start = parseInt(parts[0], 10);
+      end = parseInt(parts[1], 10);
+      if (isNaN(start) || isNaN(end) || start < 0 || end < start) {
+        isSatisfiable = false;
+        continue;
+      }
+    }
+
+    // Ensure end doesn't exceed file size
+    end = Math.min(end, fileSize - 1);
+
+    // Check if range is satisfiable
+    if (start >= fileSize) {
+      isSatisfiable = false;
+      continue;
+    }
+
+    ranges.push({ start, end });
+  }
+
+  // If no valid ranges found, mark as unsatisfiable
+  if (ranges.length === 0) {
+    isSatisfiable = false;
+  }
+
+  return {
+    ranges,
+    totalSize: fileSize,
+    isSatisfiable,
+  };
+}
+
+/**
+ * Create a readable stream for partial file content
+ */
+export function createPartialFileStream(filePath: string, start: number, end: number): ReadableStream {
+  const nodeStream = createReadStream(filePath, { start, end });
+
+  return new ReadableStream({
+    start(controller) {
+      nodeStream.on('data', (chunk: Buffer) => {
+        controller.enqueue(new Uint8Array(chunk));
+      });
+
+      nodeStream.on('end', () => {
+        controller.close();
+      });
+
+      nodeStream.on('error', (error) => {
+        controller.error(error);
+      });
+    },
+
+    cancel() {
+      nodeStream.destroy();
+    },
+  });
+}
+
+/**
+ * Generate Content-Range header value
+ */
+export function generateContentRangeHeader(start: number, end: number, totalSize: number): string {
+  return `bytes ${start}-${end}/${totalSize}`;
+}
+
+/**
+ * Check if the request is a range request
+ */
+export function isRangeRequest(rangeHeader: string | undefined): boolean {
+  return Boolean(rangeHeader?.startsWith('bytes='));
 }

--- a/packages/static-file-plugin-nodejs/src/static-file-options.ts
+++ b/packages/static-file-plugin-nodejs/src/static-file-options.ts
@@ -43,3 +43,17 @@ export type RangeResult = {
   totalSize: number;
   isSatisfiable: boolean;
 };
+
+/**
+ * Range Request related constants
+ */
+export const RangeConstants = {
+  /** Range unit for HTTP Range requests */
+  BYTES: 'bytes',
+
+  /** Accept-Ranges header value for no range support */
+  NONE: 'none',
+
+  /** Range header prefix */
+  RANGE_PREFIX: 'bytes=',
+} as const;

--- a/packages/static-file-plugin-nodejs/src/static-file-options.ts
+++ b/packages/static-file-plugin-nodejs/src/static-file-options.ts
@@ -19,4 +19,27 @@ export type StaticFileOptions = {
 
   /** Last-Modified header generation (default: true) */
   lastModified?: boolean;
+
+  /** Range Request support (default: true) */
+  ranges?: boolean;
+
+  /** Maximum number of ranges per request (default: 1) */
+  maxRanges?: number;
+};
+
+/**
+ * Parsed range information
+ */
+export type ParsedRange = {
+  start: number;
+  end: number;
+};
+
+/**
+ * Range request result
+ */
+export type RangeResult = {
+  ranges: ParsedRange[];
+  totalSize: number;
+  isSatisfiable: boolean;
 };

--- a/packages/static-file-plugin-nodejs/src/static-file-plugin.ts
+++ b/packages/static-file-plugin-nodejs/src/static-file-plugin.ts
@@ -29,9 +29,6 @@ import { PLUGIN_VERSION } from './version.js';
 
 const PLUGIN_NAME = 'static-file-plugin-nodejs';
 
-/**
- * Default configuration for static file serving
- */
 const defaultOptions: Required<Omit<StaticFileOptions, 'serveFrom'>> = {
   mountAt: '/static',
   index: ['index.html'],
@@ -43,9 +40,6 @@ const defaultOptions: Required<Omit<StaticFileOptions, 'serveFrom'>> = {
   maxRanges: 1,
 };
 
-/**
- * Validates plugin options
- */
 function validateOptions(options: StaticFileOptions, log: KoriLogger): void {
   if (!options.serveFrom) {
     const errorMessage = 'Static file plugin requires a serveFrom directory';
@@ -130,7 +124,6 @@ function serveFile(
     return serveRangeRequest(req, res, fileInfo, options, log, rangeHeader);
   }
 
-  // Serve full file (existing logic)
   res.setHeader(HttpResponseHeader.CONTENT_TYPE, mimeType);
   res.setHeader(HttpResponseHeader.CONTENT_LENGTH, fileInfo.stats.size.toString());
   res.setHeader('Accept-Ranges', options.ranges ? RangeConstants.BYTES : RangeConstants.NONE);

--- a/packages/static-file-plugin-nodejs/tests/static-file-plugin.test.ts
+++ b/packages/static-file-plugin-nodejs/tests/static-file-plugin.test.ts
@@ -11,10 +11,14 @@ describe('static-file-plugin-nodejs', () => {
   let tempDir: string;
   let publicDir: string;
 
-  async function fetchFromApp(app: ReturnType<typeof createKori>, url: string): Promise<Response> {
+  async function fetchFromApp(
+    app: ReturnType<typeof createKori>,
+    url: string,
+    headers?: Record<string, string>,
+  ): Promise<Response> {
     const generated = app.generate();
     const { fetchHandler } = await generated.onInit();
-    return fetchHandler(new Request(url));
+    return fetchHandler(new Request(url, { headers }));
   }
 
   beforeEach(async () => {
@@ -31,6 +35,10 @@ describe('static-file-plugin-nodejs', () => {
     await writeFile(join(publicDir, 'image.png'), new Uint8Array(Buffer.from('fake-png-data')));
     await writeFile(join(publicDir, '.env'), 'SECRET=test');
 
+    // Create a larger test file for range testing
+    const largeContent = 'A'.repeat(1000) + 'B'.repeat(1000) + 'C'.repeat(1000);
+    await writeFile(join(publicDir, 'large-file.txt'), largeContent);
+
     // Create subdirectory with index
     await mkdir(join(publicDir, 'admin'), { recursive: true });
     await writeFile(join(publicDir, 'admin', 'index.html'), '<html><body>Admin</body></html>');
@@ -43,6 +51,253 @@ describe('static-file-plugin-nodejs', () => {
   afterEach(async () => {
     // Clean up temp directory
     await rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe('Range Request support', () => {
+    it('should include Accept-Ranges header by default', async () => {
+      const app = createKori().applyPlugin(
+        staticFilePlugin({
+          serveFrom: publicDir,
+          mountAt: '/static',
+        }),
+      );
+
+      const response = await fetchFromApp(app, 'http://localhost/static/large-file.txt');
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('Accept-Ranges')).toBe('bytes');
+    });
+
+    it('should serve partial content for valid range requests', async () => {
+      const app = createKori().applyPlugin(
+        staticFilePlugin({
+          serveFrom: publicDir,
+          mountAt: '/static',
+        }),
+      );
+
+      // Request first 500 bytes
+      const response = await fetchFromApp(app, 'http://localhost/static/large-file.txt', {
+        Range: 'bytes=0-499',
+      });
+
+      expect(response.status).toBe(206);
+      expect(response.headers.get('Content-Range')).toBe('bytes 0-499/3000');
+      expect(response.headers.get('Content-Length')).toBe('500');
+      expect(response.headers.get('Accept-Ranges')).toBe('bytes');
+
+      const content = await response.text();
+      expect(content).toBe('A'.repeat(500));
+    });
+
+    it('should handle suffix range requests', async () => {
+      const app = createKori().applyPlugin(
+        staticFilePlugin({
+          serveFrom: publicDir,
+          mountAt: '/static',
+        }),
+      );
+
+      // Request last 500 bytes
+      const response = await fetchFromApp(app, 'http://localhost/static/large-file.txt', {
+        Range: 'bytes=-500',
+      });
+
+      expect(response.status).toBe(206);
+      expect(response.headers.get('Content-Range')).toBe('bytes 2500-2999/3000');
+      expect(response.headers.get('Content-Length')).toBe('500');
+
+      const content = await response.text();
+      expect(content).toBe('C'.repeat(500));
+    });
+
+    it('should handle start range requests', async () => {
+      const app = createKori().applyPlugin(
+        staticFilePlugin({
+          serveFrom: publicDir,
+          mountAt: '/static',
+        }),
+      );
+
+      // Request from byte 2500 to end
+      const response = await fetchFromApp(app, 'http://localhost/static/large-file.txt', {
+        Range: 'bytes=2500-',
+      });
+
+      expect(response.status).toBe(206);
+      expect(response.headers.get('Content-Range')).toBe('bytes 2500-2999/3000');
+      expect(response.headers.get('Content-Length')).toBe('500');
+
+      const content = await response.text();
+      expect(content).toBe('C'.repeat(500));
+    });
+
+    it('should return 416 for unsatisfiable ranges', async () => {
+      const app = createKori().applyPlugin(
+        staticFilePlugin({
+          serveFrom: publicDir,
+          mountAt: '/static',
+        }),
+      );
+
+      // Request range beyond file size
+      const response = await fetchFromApp(app, 'http://localhost/static/large-file.txt', {
+        Range: 'bytes=5000-6000',
+      });
+
+      expect(response.status).toBe(416);
+      expect(response.headers.get('Content-Range')).toBe('bytes */3000');
+
+      const json = (await response.json()) as { error: { type: string; message: string } };
+      expect(json.error.type).toBe('RANGE_NOT_SATISFIABLE');
+    });
+
+    it('should return 416 for invalid range format', async () => {
+      const app = createKori().applyPlugin(
+        staticFilePlugin({
+          serveFrom: publicDir,
+          mountAt: '/static',
+        }),
+      );
+
+      // Invalid range format
+      const response = await fetchFromApp(app, 'http://localhost/static/large-file.txt', {
+        Range: 'bytes=invalid-range',
+      });
+
+      expect(response.status).toBe(416);
+      expect(response.headers.get('Content-Range')).toBe('bytes */3000');
+    });
+
+    it('should reject multiple ranges when maxRanges is 1', async () => {
+      const app = createKori().applyPlugin(
+        staticFilePlugin({
+          serveFrom: publicDir,
+          mountAt: '/static',
+          maxRanges: 1,
+        }),
+      );
+
+      // Multiple ranges request
+      const response = await fetchFromApp(app, 'http://localhost/static/large-file.txt', {
+        Range: 'bytes=0-499,1000-1499',
+      });
+
+      expect(response.status).toBe(416);
+
+      const json = (await response.json()) as { error: { type: string; message: string } };
+      expect(json.error.type).toBe('TOO_MANY_RANGES');
+    });
+
+    it('should disable range requests when ranges option is false', async () => {
+      const app = createKori().applyPlugin(
+        staticFilePlugin({
+          serveFrom: publicDir,
+          mountAt: '/static',
+          ranges: false,
+        }),
+      );
+
+      const response = await fetchFromApp(app, 'http://localhost/static/large-file.txt', {
+        Range: 'bytes=0-499',
+      });
+
+      // Should return full file, not partial content
+      expect(response.status).toBe(200);
+      expect(response.headers.get('Accept-Ranges')).toBe('none');
+      expect(response.headers.get('Content-Length')).toBe('3000');
+
+      const content = await response.text();
+      expect(content.length).toBe(3000);
+    });
+
+    it('should work with conditional requests and ranges', async () => {
+      const app = createKori().applyPlugin(
+        staticFilePlugin({
+          serveFrom: publicDir,
+          mountAt: '/static',
+          etag: true,
+        }),
+      );
+
+      // First request to get ETag
+      const firstResponse = await fetchFromApp(app, 'http://localhost/static/large-file.txt');
+      const etag = firstResponse.headers.get('etag');
+      expect(etag).toBeTruthy();
+
+      // Range request with matching ETag should return 304
+      if (etag) {
+        const response = await fetchFromApp(app, 'http://localhost/static/large-file.txt', {
+          Range: 'bytes=0-499',
+          'If-None-Match': etag,
+        });
+
+        expect(response.status).toBe(304);
+      }
+    });
+
+    it('should handle range requests for different MIME types', async () => {
+      const app = createKori().applyPlugin(
+        staticFilePlugin({
+          serveFrom: publicDir,
+          mountAt: '/static',
+        }),
+      );
+
+      // Test with CSS file
+      const response = await fetchFromApp(app, 'http://localhost/static/style.css', {
+        Range: 'bytes=0-9',
+      });
+
+      expect(response.status).toBe(206);
+      expect(response.headers.get('Content-Type')).toBe('text/css');
+      expect(response.headers.get('Content-Range')).toBe('bytes 0-9/19');
+
+      const content = await response.text();
+      expect(content).toBe('body { mar');
+    });
+
+    it('should handle edge cases with range boundaries', async () => {
+      const app = createKori().applyPlugin(
+        staticFilePlugin({
+          serveFrom: publicDir,
+          mountAt: '/static',
+        }),
+      );
+
+      // Request exactly to file boundary
+      const response = await fetchFromApp(app, 'http://localhost/static/large-file.txt', {
+        Range: 'bytes=0-2999',
+      });
+
+      expect(response.status).toBe(206);
+      expect(response.headers.get('Content-Range')).toBe('bytes 0-2999/3000');
+      expect(response.headers.get('Content-Length')).toBe('3000');
+
+      const content = await response.text();
+      expect(content.length).toBe(3000);
+    });
+
+    it('should handle zero-length range requests', async () => {
+      const app = createKori().applyPlugin(
+        staticFilePlugin({
+          serveFrom: publicDir,
+          mountAt: '/static',
+        }),
+      );
+
+      // Request single byte
+      const response = await fetchFromApp(app, 'http://localhost/static/large-file.txt', {
+        Range: 'bytes=0-0',
+      });
+
+      expect(response.status).toBe(206);
+      expect(response.headers.get('Content-Range')).toBe('bytes 0-0/3000');
+      expect(response.headers.get('Content-Length')).toBe('1');
+
+      const content = await response.text();
+      expect(content).toBe('A');
+    });
   });
 
   describe('basic functionality', () => {


### PR DESCRIPTION
Add HTTP Range Request support to static-file-plugin with the following improvements:

- Implement single and multipart range request handling
- Add support for partial content responses (206 status)
- Replace magic strings and numbers with named constants
- Remove redundant comments for cleaner code
- Fix changeset configuration for proper versioning

This enables efficient streaming of large files and better user experience for media content.