### PR TITLE
Add Last-Modified conditional request support to static-file-plugin

### DIFF
--- a/.changeset/multipart-range-requests.md
+++ b/.changeset/multipart-range-requests.md
@@ -1,5 +1,5 @@
 ---
-'@korix/static-file-plugin-nodejs': minor
+'@korix/static-file-plugin-nodejs': patch
 ---
 
 Add multipart range request support for HTTP 206 Partial Content

--- a/packages/static-file-plugin-nodejs/tests/static-file-plugin.test.ts
+++ b/packages/static-file-plugin-nodejs/tests/static-file-plugin.test.ts
@@ -712,8 +712,8 @@ describe('static-file-plugin-nodejs', () => {
         }),
       );
 
-      // Request with old If-Modified-Since date
-      const oldDate = new Date('2020-01-01T00:00:00.000Z').toUTCString();
+      // Request with old If-Modified-Since date (1 year ago)
+      const oldDate = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000).toUTCString();
       const response = await fetchFromApp(app, 'http://localhost/static/index.html', {
         'If-Modified-Since': oldDate,
       });
@@ -750,8 +750,8 @@ describe('static-file-plugin-nodejs', () => {
           headers: {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             'if-none-match': etag!,
-            // Use old date for If-Modified-Since to test ETag priority
-            'if-modified-since': new Date('2020-01-01T00:00:00.000Z').toUTCString(),
+            // Use old date for If-Modified-Since to test ETag priority (1 year ago)
+            'if-modified-since': new Date(Date.now() - 365 * 24 * 60 * 60 * 1000).toUTCString(),
           },
         }),
       );


### PR DESCRIPTION
## Changes

- Add Last-Modified header support for conditional requests (If-Modified-Since)
- ETag takes priority over Last-Modified when both headers are present
- Fix changeset level from minor to patch
- Add comprehensive tests for conditional request scenarios

## Features Added

1. **If-Modified-Since support**: Returns 304 Not Modified when file hasn't changed since client's timestamp
2. **Header priority**: ETag-based conditional requests take precedence over Last-Modified
3. **Proper date handling**: Handles invalid If-Modified-Since dates gracefully

## Testing

- Added tests for If-Modified-Since conditional requests
- Added tests for header priority (ETag vs Last-Modified)
- Added tests for edge cases with old timestamps

The implementation follows HTTP caching best practices and maintains backward compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved support for HTTP conditional requests using both ETag and Last-Modified headers, enhancing caching and partial content delivery.
* **Tests**
  * Added new tests to verify correct handling of If-Modified-Since and If-None-Match headers, ensuring proper 304 Not Modified responses and header precedence.
* **Chores**
  * Updated release version label to reflect a patch update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->