### PR TITLE
feat(static-file-plugin): Add immutable Cache-Control directive support

### DIFF
--- a/.changeset/static-file-plugin-nodejs.md
+++ b/.changeset/static-file-plugin-nodejs.md
@@ -4,4 +4,10 @@
 
 Add static file serving plugin for Node.js
 
-Provides secure static file serving with streaming, MIME type detection, and caching headers.
+- Secure static file serving with path traversal protection
+- Streaming file delivery without buffering
+- MIME type detection and proper Content-Type headers
+- ETag and Last-Modified support for conditional requests
+- Range request support for partial content delivery
+- Cache-Control headers with optional immutable directive
+- Comprehensive README with usage examples and best practices

--- a/packages/static-file-plugin-nodejs/README.md
+++ b/packages/static-file-plugin-nodejs/README.md
@@ -337,8 +337,31 @@ staticFilePlugin({
   maxAge: 3600, // Cache-Control: public, max-age=3600
   etag: true, // ETag: "1234567890abcdef"
   lastModified: true, // Last-Modified: Wed, 21 Oct 2015 07:28:00 GMT
+  immutable: true, // Cache-Control: public, max-age=3600, immutable
 });
 ```
+
+### Immutable Caching
+
+The `immutable` directive tells browsers not to revalidate cached resources even on reload:
+
+```typescript
+// For assets with cache-busting filenames
+staticFilePlugin({
+  serveFrom: './dist/assets',
+  maxAge: 31536000, // 1 year
+  immutable: true, // Safe for versioned files like app.abc123.js
+});
+
+// For regular files that may change
+staticFilePlugin({
+  serveFrom: './public',
+  maxAge: 3600, // 1 hour
+  immutable: false, // Default - will revalidate on reload
+});
+```
+
+**Important**: Only use `immutable: true` with files that have cache-busting filenames (e.g., `app.abc123.js`). Files that might change should use the default `immutable: false`.
 
 ### Conditional Requests
 

--- a/packages/static-file-plugin-nodejs/src/static-file-options.ts
+++ b/packages/static-file-plugin-nodejs/src/static-file-options.ts
@@ -20,6 +20,9 @@ export type StaticFileOptions = {
   /** Last-Modified header generation (default: true) */
   lastModified?: boolean;
 
+  /** Enable immutable Cache-Control directive (default: false) */
+  immutable?: boolean;
+
   /** Range Request support (default: true) */
   ranges?: boolean;
 

--- a/packages/static-file-plugin-nodejs/src/static-file-plugin.ts
+++ b/packages/static-file-plugin-nodejs/src/static-file-plugin.ts
@@ -45,6 +45,7 @@ const defaultOptions: Required<Omit<StaticFileOptions, 'serveFrom'>> = {
   maxAge: 0,
   etag: true,
   lastModified: true,
+  immutable: false,
   ranges: true,
   maxRanges: 1,
 };
@@ -86,10 +87,14 @@ function removeMountPrefix(pathname: string, mountAt: string): string {
 function setCacheHeaders(
   res: KoriResponse,
   fileInfo: ExistingFileInfo,
-  options: Required<Pick<StaticFileOptions, 'maxAge' | 'etag' | 'lastModified'>>,
+  options: Required<Pick<StaticFileOptions, 'maxAge' | 'etag' | 'lastModified' | 'immutable'>>,
 ): void {
   if (options.maxAge > 0) {
-    res.setHeader(HttpResponseHeader.CACHE_CONTROL, `public, max-age=${options.maxAge}`);
+    let cacheControl = `public, max-age=${options.maxAge}`;
+    if (options.immutable) {
+      cacheControl += ', immutable';
+    }
+    res.setHeader(HttpResponseHeader.CACHE_CONTROL, cacheControl);
   } else {
     res.setHeader(HttpResponseHeader.CACHE_CONTROL, 'no-cache');
   }
@@ -134,7 +139,7 @@ function serveFile(
   req: KoriRequest,
   res: KoriResponse,
   fileInfo: ExistingFileInfo,
-  options: Required<Pick<StaticFileOptions, 'maxAge' | 'etag' | 'lastModified' | 'ranges' | 'maxRanges'>>,
+  options: Required<Pick<StaticFileOptions, 'maxAge' | 'etag' | 'lastModified' | 'immutable' | 'ranges' | 'maxRanges'>>,
   log: KoriLogger,
 ): KoriResponse {
   const mimeType = detectMimeType(fileInfo.path);
@@ -190,7 +195,7 @@ function serveRangeRequest(
   req: KoriRequest,
   res: KoriResponse,
   fileInfo: ExistingFileInfo,
-  options: Required<Pick<StaticFileOptions, 'maxAge' | 'etag' | 'lastModified' | 'ranges' | 'maxRanges'>>,
+  options: Required<Pick<StaticFileOptions, 'maxAge' | 'etag' | 'lastModified' | 'immutable' | 'ranges' | 'maxRanges'>>,
   log: KoriLogger,
   rangeResult: RangeResult,
 ): KoriResponse {
@@ -229,7 +234,7 @@ function serveSingleRange(
   req: KoriRequest,
   res: KoriResponse,
   fileInfo: ExistingFileInfo,
-  options: Required<Pick<StaticFileOptions, 'maxAge' | 'etag' | 'lastModified' | 'ranges' | 'maxRanges'>>,
+  options: Required<Pick<StaticFileOptions, 'maxAge' | 'etag' | 'lastModified' | 'immutable' | 'ranges' | 'maxRanges'>>,
   log: KoriLogger,
   range: { start: number; end: number },
   mimeType: string,
@@ -264,7 +269,7 @@ function serveMultipartRange(
   req: KoriRequest,
   res: KoriResponse,
   fileInfo: ExistingFileInfo,
-  options: Required<Pick<StaticFileOptions, 'maxAge' | 'etag' | 'lastModified' | 'ranges' | 'maxRanges'>>,
+  options: Required<Pick<StaticFileOptions, 'maxAge' | 'etag' | 'lastModified' | 'immutable' | 'ranges' | 'maxRanges'>>,
   log: KoriLogger,
   ranges: { start: number; end: number }[],
   mimeType: string,


### PR DESCRIPTION
# Add immutable Cache-Control directive support to static file plugin

## Overview

This PR adds support for the `immutable` Cache-Control directive to the static file plugin, enabling efficient caching for assets with cache-busting filenames.

## What's New

- ✅ **immutable option**: New boolean option in `StaticFileOptions` (default: `false`)
- ✅ **Cache-Control enhancement**: Appends `, immutable` when enabled
- ✅ **Documentation**: Comprehensive usage examples and best practices
- ✅ **Backward compatible**: Default behavior unchanged

## Usage

```typescript
// For assets with cache-busting filenames (app.abc123.js)
staticFilePlugin({
  serveFrom: "./dist/assets",
  maxAge: 31536000, // 1 year
  immutable: true, // No revalidation even on reload
});

// For regular files that may change
staticFilePlugin({
  serveFrom: "./public",
  maxAge: 3600, // 1 hour
  immutable: false, // Default - will revalidate on reload
});
```

## Benefits

- **Performance**: Eliminates unnecessary revalidation requests on browser reload
- **Bandwidth savings**: Reduces 304 responses for truly immutable assets
- **Modern web optimization**: Supports best practices for cache-busting workflows

## Technical Details

- Only applies when `maxAge > 0`
- Safe to use with versioned/hashed filenames
- Backward compatible with existing configurations
- Follows RFC 8246 specifications

## Files Changed

- `packages/static-file-plugin-nodejs/src/static-file-options.ts` - Type definition
- `packages/static-file-plugin-nodejs/src/static-file-plugin.ts` - Implementation
- `packages/static-file-plugin-nodejs/README.md` - Documentation
- `.changeset/static-file-plugin-nodejs.md` - Changeset update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `immutable` directive in cache control headers, allowing browsers to cache static files without revalidation when enabled.
  * Introduced an `immutable` option in plugin configuration for enhanced caching of versioned assets.

* **Documentation**
  * Updated documentation to explain the new `immutable` caching option, including usage examples and best practices.
  * Expanded changelog with a detailed list of plugin features and capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->