### PR TITLE
Fix Node.js built-in modules external configuration

### DIFF
--- a/packages/nodejs-adapter/tsdown.config.js
+++ b/packages/nodejs-adapter/tsdown.config.js
@@ -6,5 +6,5 @@ export default defineConfig({
   dts: true,
   clean: false,
   sourcemap: true,
-  external: ['@korix/kori'],
+  external: ['@korix/kori', '@hono/node-server'],
 });

--- a/packages/script/tsdown.config.js
+++ b/packages/script/tsdown.config.js
@@ -6,4 +6,5 @@ export default defineConfig({
   dts: true,
   clean: false,
   sourcemap: true,
+  external: ['node:fs', 'node:fs/promises', 'node:path', 'node:os'],
 });


### PR DESCRIPTION
## Changes

Fixed Node.js built-in modules external configuration in tsdown configs.

### Modified Files

#### packages/script/tsdown.config.js
- Added Node.js built-in modules to external configuration:
  - `node:fs`
  - `node:fs/promises` 
  - `node:path`
  - `node:os`

#### packages/nodejs-adapter/tsdown.config.js
- Added `@hono/node-server` to external configuration

### Background

These packages were using Node.js built-in modules and external libraries but they were not specified as external in tsdown configuration. This fix ensures these dependencies are properly treated as external and prevents them from being bundled.

### Verification

- `pnpm build` completed without errors
- All 15 packages built successfully
- Pre-commit hooks (lint, format, typecheck) all passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to exclude additional external dependencies from the bundle process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->