### PR TITLE
Exit changeset prerelease mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "alpha",
   "initialVersions": {
     "@korix/body-limit-plugin": "0.1.0",


### PR DESCRIPTION
# Exit changeset prerelease mode

This PR exits the alpha prerelease mode to prepare for stable releases.

## Changes

- Updated `.changeset/pre.json` to exit alpha prerelease mode
- This allows the next `changeset version` to create stable release versions (e.g., 0.1.0 instead of 0.1.0-alpha.x)

## Background

The project has been in alpha prerelease mode during development. With the current set of features stabilized, we're ready to move towards stable releases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration to adjust release process settings. No impact on end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->