### PR TITLE
Remove internal info from 415 Unsupported Media Type errors

### DIFF
--- a/.changeset/security-fix-unsupported-media-type.md
+++ b/.changeset/security-fix-unsupported-media-type.md
@@ -1,0 +1,15 @@
+---
+'@korix/kori': patch
+---
+
+Remove internal information from 415 Unsupported Media Type errors
+
+Remove supportedTypes, requestedType, and internal error messages from 415 error responses to prevent information disclosure. The error response now returns only minimal information while maintaining consistency with other Kori error formats.
+
+Security improvements:
+- Remove supportedTypes array from error response
+- Remove requestedType from error response  
+- Remove internal error messages
+- Use consistent error format with other Kori errors
+
+This change prevents potential information leakage about server implementation details.

--- a/packages/kori/src/kori/route-handler-factory.ts
+++ b/packages/kori/src/kori/route-handler-factory.ts
@@ -207,10 +207,10 @@ function createRequestValidationErrorHandler<
     // 3. Handle pre-validation unsupported media type errors with 415 status
     if (err.body?.stage === 'pre-validation' && err.body.type === 'UNSUPPORTED_MEDIA_TYPE') {
       return ctx.res.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE).json({
-        error: 'Unsupported Media Type',
-        message: err.body.message,
-        supportedTypes: err.body.supportedTypes,
-        requestedType: err.body.requestedType,
+        error: {
+          type: 'UNSUPPORTED_MEDIA_TYPE',
+          message: 'Unsupported Media Type',
+        },
       });
     }
 


### PR DESCRIPTION
## Summary

Remove internal information from 415 Unsupported Media Type error responses to prevent information disclosure.

## Changes

- Remove `supportedTypes` array from 415 error responses
- Remove `requestedType` from 415 error responses  
- Remove internal error messages (`err.body.message`)
- Use consistent error format with other Kori errors

## Security Impact

Previously, 415 errors exposed:
- Server's supported content types (implementation details)
- Confirmation of client's request type
- Internal error messages

Now returns only:
```json
{
  "error": {
    "type": "UNSUPPORTED_MEDIA_TYPE",
    "message": "Unsupported Media Type"
  }
}
```

## Testing

- HTTP status code 415 is still returned correctly
- Error format is consistent with other Kori error responses
- No internal information is leaked to clients

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security for 415 Unsupported Media Type error responses by removing internal details from error messages and aligning the format with other error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->