### PR TITLE
Use consistent unsupportedMediaType() method for 415 errors

### DIFF
--- a/.changeset/improve-unsupported-media-type-consistency.md
+++ b/.changeset/improve-unsupported-media-type-consistency.md
@@ -1,0 +1,14 @@
+---
+'@korix/kori': patch
+---
+
+Use consistent unsupportedMediaType() method for 415 errors
+
+Replace manual status and JSON setup with the existing unsupportedMediaType() method to maintain consistency with other error response patterns in the codebase.
+
+Improvements:
+- Use ctx.res.unsupportedMediaType() instead of manual status/json setup
+- Remove unnecessary HttpStatus import
+- Better consistency with other error response methods (badRequest, notFound, etc.)
+
+This change makes the codebase more consistent and easier to maintain.

--- a/packages/kori/src/kori/route-handler-factory.ts
+++ b/packages/kori/src/kori/route-handler-factory.ts
@@ -11,7 +11,6 @@ import {
   type KoriOnErrorHook,
   type KoriOnFinallyHook,
 } from '../hook/index.js';
-import { HttpStatus } from '../http/index.js';
 import {
   resolveRequestValidationFunction,
   type InferRequestValidatorError,
@@ -206,12 +205,7 @@ function createRequestValidationErrorHandler<
 
     // 3. Handle pre-validation unsupported media type errors with 415 status
     if (err.body?.stage === 'pre-validation' && err.body.type === 'UNSUPPORTED_MEDIA_TYPE') {
-      return ctx.res.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE).json({
-        error: {
-          type: 'UNSUPPORTED_MEDIA_TYPE',
-          message: 'Unsupported Media Type',
-        },
-      });
+      return ctx.res.unsupportedMediaType();
     }
 
     // 4. Default validation error handling with 400 status


### PR DESCRIPTION
## Summary

Use the consistent `unsupportedMediaType()` method for 415 Unsupported Media Type errors instead of manual status and JSON setup.

## Changes

- Replace `ctx.res.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE).json({...})` with `ctx.res.unsupportedMediaType()`
- Remove unnecessary `HttpStatus` import
- Simplify error handling code

## Benefits

- **Consistency**: Aligns with other error response methods (`badRequest()`, `notFound()`, `internalError()`, etc.)
- **Maintainability**: Uses the existing framework method instead of manual setup
- **Code simplicity**: Reduces boilerplate code

## Before vs After

**Before:**
```typescript
return ctx.res.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE).json({
  error: {
    type: 'UNSUPPORTED_MEDIA_TYPE',
    message: 'Unsupported Media Type',
  },
});
```

**After:**
```typescript
return ctx.res.unsupportedMediaType();
```

This change maintains the exact same functionality while improving code consistency and reducing complexity.