### PR TITLE
Implement response abort and unified defer pattern

### DIFF
--- a/.changeset/response-abort-feature.md
+++ b/.changeset/response-abort-feature.md
@@ -1,0 +1,14 @@
+---
+'@korix/kori': patch
+---
+
+Reverse onResponse hook execution order and add response abort functionality
+
+- onResponse hooks now execute in normal order instead of reverse order
+- OnRequest hook return type changed from KoriResponse to KoriResponseAbort
+- Response abort functionality for early request termination
+- Added `res.abort()` method that returns a type-safe abort object
+- Added `res.isAborted()` method to check abort status
+- Hook execution automatically respects abort state and skips remaining hooks
+- Type-safe abort handling with `KoriResponseAbort` type and `isKoriResponseAbort` guard function
+- Improved error handling in hooks with try-catch blocks

--- a/.changeset/response-abort-feature.md
+++ b/.changeset/response-abort-feature.md
@@ -2,13 +2,38 @@
 '@korix/kori': patch
 ---
 
-Reverse onResponse hook execution order and add response abort functionality
+BREAKING: Remove onResponse, onFinally, and onClose hooks and introduce unified defer pattern
 
-- onResponse hooks now execute in normal order instead of reverse order
-- OnRequest hook return type changed from KoriResponse to KoriResponseAbort
+BREAKING CHANGES:
+
+- Removed `onResponse` hook - was redundant with new defer pattern
+- Removed `onFinally` hook - use `ctx.defer()` within onRequest for post-request processing
+- Removed `onClose` hook - use `ctx.defer()` within onStart for shutdown cleanup
+- Renamed `onInit` → `onStart` for consistency
+- Hook execution flow changed from `onRequest → Handler → onResponse → onFinally` to `onRequest → Handler → defer callbacks (reverse order)`
+- Instance lifecycle changed from `onInit → ... → onClose` to `onStart → ... → defer callbacks (reverse order)`
+- Simplified to 2-hook architecture for handlers: `onRequest` and `onError`
+- Simplified to 1-hook architecture for instances: `onStart`
+
+NEW FEATURES:
+
 - Response abort functionality for early request termination
-- Added `res.abort()` method that returns a type-safe abort object
+- Added `KoriResponseAbortObject` for type-safe early termination in onRequest hooks
 - Added `res.isAborted()` method to check abort status
 - Hook execution automatically respects abort state and skips remaining hooks
 - Type-safe abort handling with `KoriResponseAbort` type and `isKoriResponseAbort` guard function
-- Improved error handling in hooks with try-catch blocks
+- New `ctx.defer()` method for registering cleanup operations that execute after handlers (Handler Context)
+- New `ctx.defer()` method for registering shutdown cleanup operations in onStart hooks (Instance Context)
+- Defer callbacks execute in reverse order (LIFO) ensuring proper cleanup sequence
+- Type-safe defer pattern with same context available in deferred callbacks
+- Unified defer pattern across both Handler Context and Instance Context
+
+MIGRATION:
+
+- Replace `app.onResponse(hook)` with `ctx.defer(callback)` within onRequest hooks
+- Replace `app.onFinally(hook)` with `ctx.defer(callback)` within onRequest hooks
+- Replace `app.onInit(hook)` with `app.onStart(hook)`
+- Replace `app.onClose(hook)` with `ctx.defer(callback)` within onStart hooks
+- Defer callbacks execute in reverse order (LIFO) and always run (success or error)
+- Move cleanup operations from onResponse/onFinally hooks to defer calls within onRequest
+- Move shutdown operations from onClose hooks to defer calls within onStart

--- a/docs/en/core/kori.md
+++ b/docs/en/core/kori.md
@@ -54,32 +54,26 @@ app.log().error('Something went wrong', { error });
 
 Lifecycle hooks execute once per application lifecycle.
 
-#### `app.onInit(hook)`
+#### `app.onStart(hook)`
 
 Execute code when the application initializes.
 
 ```typescript
-app.onInit(async (ctx) => {
+app.onStart(async (ctx) => {
   // Initialize database connection
   const db = await connectDatabase();
+
+  // Defer cleanup for shutdown
+  ctx.defer(async (ctx) => {
+    // Clean up resources
+    await ctx.env.db.close();
+  });
+
   return ctx.withEnv({ db });
 });
 ```
 
 **Type:** `(ctx: KoriInstanceContext<Env>) => Promise<KoriInstanceContext<Env & EnvExt>> | KoriInstanceContext<Env & EnvExt>`
-
-#### `app.onClose(hook)`
-
-Execute code when the application shuts down.
-
-```typescript
-app.onClose(async (ctx) => {
-  // Clean up resources
-  await ctx.env.db.close();
-});
-```
-
-**Type:** `(ctx: KoriInstanceContext<Env>) => Promise<void> | void`
 
 ### Handler Hooks
 

--- a/packages/body-limit-plugin/src/body-limit-plugin.ts
+++ b/packages/body-limit-plugin/src/body-limit-plugin.ts
@@ -235,11 +235,14 @@ export function bodyLimitPlugin<Env extends KoriEnvironment, Req extends KoriReq
                 userAgent: req.headers()['user-agent'],
               });
 
-              return res.status(HttpStatus.BAD_REQUEST).json({
-                error: 'Bad Request',
-                message: 'Invalid Content-Length header',
-                code: ERROR_CODES.INVALID_CONTENT_LENGTH,
-              });
+              return res
+                .status(HttpStatus.BAD_REQUEST)
+                .json({
+                  error: 'Bad Request',
+                  message: 'Invalid Content-Length header',
+                  code: ERROR_CODES.INVALID_CONTENT_LENGTH,
+                })
+                .abort();
             }
 
             const contentLength = parseInt(contentLengthHeader, 10);

--- a/packages/file-plugin-nodejs/tests/serve-static-plugin.test.ts
+++ b/packages/file-plugin-nodejs/tests/serve-static-plugin.test.ts
@@ -17,7 +17,7 @@ describe('serve-static-plugin-nodejs', () => {
     headers?: Record<string, string>,
   ): Promise<Response> {
     const generated = app.generate();
-    const { fetchHandler } = await generated.onInit();
+    const { fetchHandler } = await generated.onStart();
     return fetchHandler(new Request(url, { headers }));
   }
 
@@ -659,7 +659,7 @@ describe('serve-static-plugin-nodejs', () => {
 
       // Second request with If-None-Match header
       const generated = app.generate();
-      const { fetchHandler } = await generated.onInit();
+      const { fetchHandler } = await generated.onStart();
       const secondResponse = await fetchHandler(
         new Request('http://localhost/static/index.html', {
           headers: {
@@ -690,7 +690,7 @@ describe('serve-static-plugin-nodejs', () => {
 
       // Second request with If-Modified-Since header (same timestamp)
       const generated = app.generate();
-      const { fetchHandler } = await generated.onInit();
+      const { fetchHandler } = await generated.onStart();
       const secondResponse = await fetchHandler(
         new Request('http://localhost/static/index.html', {
           headers: {
@@ -744,7 +744,7 @@ describe('serve-static-plugin-nodejs', () => {
 
       // Request with both headers - ETag should take priority
       const generated = app.generate();
-      const { fetchHandler } = await generated.onInit();
+      const { fetchHandler } = await generated.onStart();
       const secondResponse = await fetchHandler(
         new Request('http://localhost/static/index.html', {
           headers: {

--- a/packages/kori/src/context/handler-context.ts
+++ b/packages/kori/src/context/handler-context.ts
@@ -1,3 +1,5 @@
+import { type MaybePromise } from '../util/index.js';
+
 import { type KoriEnvironment } from './environment.js';
 import { type KoriRequest } from './request.js';
 import { type KoriResponse } from './response.js';
@@ -8,25 +10,33 @@ export type KoriHandlerContext<Env extends KoriEnvironment, Req extends KoriRequ
   res: Res;
   withReq<ReqExt>(reqExt: ReqExt): KoriHandlerContext<Env, Req & ReqExt, Res>;
   withRes<ResExt>(resExt: ResExt): KoriHandlerContext<Env, Req, Res & ResExt>;
+  defer(callback: (ctx: KoriHandlerContext<Env, Req, Res>) => MaybePromise<void>): void;
 };
 
 // --- Internal Implementation ---
 
-type CtxState = {
+type KoriHandlerContextBase = KoriHandlerContext<KoriEnvironment, KoriRequest, KoriResponse>;
+
+type HandlerCtxState = {
   env: KoriEnvironment;
   req: KoriRequest;
   res: KoriResponse;
+  deferStack: ((ctx: KoriHandlerContextBase) => MaybePromise<void>)[];
 };
 
 const handlerContextPrototype = {
-  withReq<ReqExt extends object>(this: CtxState & { req: KoriRequest }, reqExt: ReqExt) {
+  withReq<ReqExt extends object>(this: HandlerCtxState, reqExt: ReqExt) {
     Object.assign(this.req, reqExt);
     return this;
   },
 
-  withRes<ResExt extends object>(this: CtxState, resExt: ResExt) {
+  withRes<ResExt extends object>(this: HandlerCtxState, resExt: ResExt) {
     Object.assign(this.res, resExt);
     return this;
+  },
+
+  defer(this: HandlerCtxState, callback: (ctx: KoriHandlerContextBase) => MaybePromise<void>) {
+    this.deferStack.push(callback);
   },
 };
 
@@ -35,9 +45,25 @@ export function createKoriHandlerContext<
   Req extends KoriRequest,
   Res extends KoriResponse,
 >({ env, req, res }: { env: Env; req: Req; res: Res }): KoriHandlerContext<Env, Req, Res> {
-  const ctx = Object.create(handlerContextPrototype) as CtxState;
+  const ctx = Object.create(handlerContextPrototype) as HandlerCtxState;
   ctx.env = env;
   ctx.req = req;
   ctx.res = res;
+  ctx.deferStack = [];
   return ctx as unknown as KoriHandlerContext<Env, Req, Res>;
+}
+
+// Internal function to execute deferred callbacks
+export async function executeHandlerDeferredCallbacks(ctx: KoriHandlerContextBase): Promise<void> {
+  const ctxState = ctx as unknown as HandlerCtxState;
+  const deferStack = ctxState.deferStack;
+
+  // Execute in reverse order (LIFO)
+  for (let i = deferStack.length - 1; i >= 0; i--) {
+    try {
+      await deferStack[i]?.(ctx);
+    } catch (error) {
+      ctx.req.log().error('Defer callback error:', { error });
+    }
+  }
 }

--- a/packages/kori/src/context/index.ts
+++ b/packages/kori/src/context/index.ts
@@ -1,6 +1,14 @@
 export { createKoriEnvironment, type KoriEnvironment } from './environment.js';
-export { createKoriHandlerContext, type KoriHandlerContext } from './handler-context.js';
-export { createKoriInstanceContext, type KoriInstanceContext } from './instance-context.js';
+export {
+  createKoriHandlerContext,
+  executeHandlerDeferredCallbacks,
+  type KoriHandlerContext,
+} from './handler-context.js';
+export {
+  createKoriInstanceContext,
+  executeInstanceDeferredCallbacks,
+  type KoriInstanceContext,
+} from './instance-context.js';
 export { createKoriRequest, type KoriRequest } from './request.js';
 export { createKoriResponse, isKoriResponse, type KoriResponse } from './response.js';
-export { isKoriResponseAbort, type KoriResponseAbort } from './response-abort.js';
+export { isKoriResponseAbort, type KoriResponseAbort, KoriResponseAbortObject } from './response-abort.js';

--- a/packages/kori/src/context/index.ts
+++ b/packages/kori/src/context/index.ts
@@ -3,3 +3,4 @@ export { createKoriHandlerContext, type KoriHandlerContext } from './handler-con
 export { createKoriInstanceContext, type KoriInstanceContext } from './instance-context.js';
 export { createKoriRequest, type KoriRequest } from './request.js';
 export { createKoriResponse, isKoriResponse, type KoriResponse } from './response.js';
+export { isKoriResponseAbort, type KoriResponseAbort } from './response-abort.js';

--- a/packages/kori/src/context/instance-context.ts
+++ b/packages/kori/src/context/instance-context.ts
@@ -1,15 +1,53 @@
+import { type MaybePromise } from '../util/index.js';
+
 import { type KoriEnvironment } from './environment.js';
 
 export type KoriInstanceContext<Env extends KoriEnvironment> = {
   env: Env;
   withEnv<EnvExt>(envExt: EnvExt): KoriInstanceContext<Env & EnvExt>;
+  defer(callback: (ctx: KoriInstanceContext<Env>) => MaybePromise<void>): void;
+};
+
+// --- Internal Implementation ---
+
+type KoriInstanceContextBase = KoriInstanceContext<KoriEnvironment>;
+
+type InstanceCtxState = {
+  env: KoriEnvironment;
+  deferStack: ((ctx: KoriInstanceContextBase) => MaybePromise<void>)[];
+};
+
+const instanceContextPrototype = {
+  withEnv<EnvExt extends object>(this: InstanceCtxState, envExt: EnvExt) {
+    Object.assign(this.env, envExt);
+    return this;
+  },
+
+  defer(this: InstanceCtxState, callback: (ctx: KoriInstanceContextBase) => MaybePromise<void>) {
+    this.deferStack.push(callback);
+  },
 };
 
 export function createKoriInstanceContext<Env extends KoriEnvironment>(env: Env): KoriInstanceContext<Env> {
-  return {
-    env,
-    withEnv: function <EnvExt>(envExt: EnvExt) {
-      return createKoriInstanceContext({ ...env, ...envExt });
-    },
-  };
+  const ctx = Object.create(instanceContextPrototype) as InstanceCtxState;
+  ctx.env = env;
+  ctx.deferStack = [];
+  return ctx as unknown as KoriInstanceContext<Env>;
+}
+
+// Internal function to execute deferred callbacks for instance context
+export async function executeInstanceDeferredCallbacks(ctx: KoriInstanceContextBase): Promise<void> {
+  const ctxState = ctx as unknown as InstanceCtxState;
+  const deferStack = ctxState.deferStack;
+
+  // Execute in reverse order (LIFO)
+  for (let i = deferStack.length - 1; i >= 0; i--) {
+    try {
+      await deferStack[i]?.(ctx);
+    } catch (error) {
+      // TODO: Log error
+      // eslint-disable-next-line no-console
+      console.error('Instance defer callback error:', error);
+    }
+  }
 }

--- a/packages/kori/src/context/response-abort.ts
+++ b/packages/kori/src/context/response-abort.ts
@@ -1,0 +1,9 @@
+const KoriResponseAbortBrand = Symbol('kori-response-abort');
+
+export const KoriResponseAbortObject = { [KoriResponseAbortBrand]: true } as const;
+
+export type KoriResponseAbort = typeof KoriResponseAbortObject;
+
+export function isKoriResponseAbort(value: unknown): value is KoriResponseAbort {
+  return typeof value === 'object' && value !== null && KoriResponseAbortBrand in value;
+}

--- a/packages/kori/src/fetch-handler/fetch-handler.ts
+++ b/packages/kori/src/fetch-handler/fetch-handler.ts
@@ -4,5 +4,5 @@ export type KoriInitializedFetchHandler = {
 };
 
 export type KoriFetchHandler = {
-  onInit: () => Promise<KoriInitializedFetchHandler>;
+  onStart: () => Promise<KoriInitializedFetchHandler>;
 };

--- a/packages/kori/src/hook/handler-hook.ts
+++ b/packages/kori/src/hook/handler-hook.ts
@@ -3,6 +3,7 @@ import {
   type KoriHandlerContext,
   type KoriRequest,
   type KoriResponse,
+  type KoriResponseAbort,
 } from '../context/index.js';
 import { type MaybePromise } from '../util/index.js';
 
@@ -14,7 +15,7 @@ export type KoriOnRequestHook<
   ResExt = unknown,
 > = (
   ctx: KoriHandlerContext<Env, Req, Res>,
-) => MaybePromise<KoriHandlerContext<Env, Req & ReqExt, Res & ResExt> | KoriResponse | void>;
+) => MaybePromise<KoriHandlerContext<Env, Req & ReqExt, Res & ResExt> | KoriResponseAbort | void>;
 
 export type KoriOnResponseHook<Env extends KoriEnvironment, Req extends KoriRequest, Res extends KoriResponse> = (
   ctx: KoriHandlerContext<Env, Req, Res>,

--- a/packages/kori/src/hook/handler-hook.ts
+++ b/packages/kori/src/hook/handler-hook.ts
@@ -17,15 +17,7 @@ export type KoriOnRequestHook<
   ctx: KoriHandlerContext<Env, Req, Res>,
 ) => MaybePromise<KoriHandlerContext<Env, Req & ReqExt, Res & ResExt> | KoriResponseAbort | void>;
 
-export type KoriOnResponseHook<Env extends KoriEnvironment, Req extends KoriRequest, Res extends KoriResponse> = (
-  ctx: KoriHandlerContext<Env, Req, Res>,
-) => MaybePromise<void>;
-
 export type KoriOnErrorHook<Env extends KoriEnvironment, Req extends KoriRequest, Res extends KoriResponse> = (
   ctx: KoriHandlerContext<Env, Req, Res>,
   err: unknown,
-) => MaybePromise<void>;
-
-export type KoriOnFinallyHook<Env extends KoriEnvironment, Req extends KoriRequest, Res extends KoriResponse> = (
-  ctx: KoriHandlerContext<Env, Req, Res>,
 ) => MaybePromise<void>;

--- a/packages/kori/src/hook/index.ts
+++ b/packages/kori/src/hook/index.ts
@@ -1,7 +1,2 @@
-export {
-  type KoriOnErrorHook,
-  type KoriOnFinallyHook,
-  type KoriOnRequestHook,
-  type KoriOnResponseHook,
-} from './handler-hook.js';
-export { type KoriOnCloseHook, type KoriOnInitHook } from './instance-hook.js';
+export { type KoriOnErrorHook, type KoriOnRequestHook } from './handler-hook.js';
+export { type KoriOnStartHook } from './instance-hook.js';

--- a/packages/kori/src/hook/instance-hook.ts
+++ b/packages/kori/src/hook/instance-hook.ts
@@ -1,8 +1,6 @@
 import { type KoriEnvironment, type KoriInstanceContext } from '../context/index.js';
 import { type MaybePromise } from '../util/index.js';
 
-export type KoriOnInitHook<Env extends KoriEnvironment, EnvExt = unknown> = (
+export type KoriOnStartHook<Env extends KoriEnvironment, EnvExt = unknown> = (
   ctx: KoriInstanceContext<Env>,
 ) => MaybePromise<KoriInstanceContext<Env & EnvExt> | void>;
-
-export type KoriOnCloseHook<Env extends KoriEnvironment> = (ctx: KoriInstanceContext<Env>) => MaybePromise<void>;

--- a/packages/kori/src/index.ts
+++ b/packages/kori/src/index.ts
@@ -5,22 +5,17 @@ export {
   createKoriRequest,
   createKoriResponse,
   isKoriResponse,
+  isKoriResponseAbort,
   type KoriEnvironment,
   type KoriHandlerContext,
   type KoriInstanceContext,
   type KoriRequest,
   type KoriResponse,
+  type KoriResponseAbort,
 } from './context/index.js';
 export { type KoriError, type KoriValidationConfigError } from './error/index.js';
 export { type KoriFetchHandler, type KoriInitializedFetchHandler } from './fetch-handler/index.js';
-export {
-  type KoriOnCloseHook,
-  type KoriOnErrorHook,
-  type KoriOnFinallyHook,
-  type KoriOnInitHook,
-  type KoriOnRequestHook,
-  type KoriOnResponseHook,
-} from './hook/index.js';
+export { type KoriOnErrorHook, type KoriOnRequestHook, type KoriOnStartHook } from './hook/index.js';
 export {
   ContentType,
   type ContentTypeValue,

--- a/packages/kori/src/kori/kori.ts
+++ b/packages/kori/src/kori/kori.ts
@@ -1,13 +1,6 @@
 import { type KoriEnvironment, type KoriRequest, type KoriResponse } from '../context/index.js';
 import { type KoriFetchHandler } from '../fetch-handler/index.js';
-import {
-  type KoriOnCloseHook,
-  type KoriOnErrorHook,
-  type KoriOnFinallyHook,
-  type KoriOnInitHook,
-  type KoriOnRequestHook,
-  type KoriOnResponseHook,
-} from '../hook/index.js';
+import { type KoriOnErrorHook, type KoriOnRequestHook, type KoriOnStartHook } from '../hook/index.js';
 import { type KoriLogger } from '../logging/index.js';
 import { type KoriPlugin } from '../plugin/index.js';
 import { type KoriRequestValidatorDefault } from '../request-validation/index.js';
@@ -86,17 +79,16 @@ export type Kori<
   // Logger
   log(): KoriLogger;
 
-  // Lifestyle Hooks
-  onInit<EnvExt>(hook: KoriOnInitHook<Env, EnvExt>): Kori<Env & EnvExt, Req, Res, RequestValidator, ResponseValidator>;
-  onClose(hook: KoriOnCloseHook<Env>): Kori<Env, Req, Res, RequestValidator, ResponseValidator>;
+  // Lifecycle Hooks
+  onStart<EnvExt>(
+    hook: KoriOnStartHook<Env, EnvExt>,
+  ): Kori<Env & EnvExt, Req, Res, RequestValidator, ResponseValidator>;
 
   // Handler Hooks
   onRequest<ReqExt, ResExt>(
     hook: KoriOnRequestHook<Env, Req, Res, ReqExt, ResExt>,
   ): Kori<Env, Req & ReqExt, Res & ResExt, RequestValidator, ResponseValidator>;
-  onResponse(hook: KoriOnResponseHook<Env, Req, Res>): Kori<Env, Req, Res, RequestValidator, ResponseValidator>;
   onError(hook: KoriOnErrorHook<Env, Req, Res>): Kori<Env, Req, Res, RequestValidator, ResponseValidator>;
-  onFinally(hook: KoriOnFinallyHook<Env, Req, Res>): Kori<Env, Req, Res, RequestValidator, ResponseValidator>;
 
   // Plugin
   applyPlugin<EnvExt, ReqExt, ResExt>(

--- a/packages/kori/tests/error-response-json-only.test.ts
+++ b/packages/kori/tests/error-response-json-only.test.ts
@@ -16,7 +16,7 @@ describe('Error Response JSON Only', () => {
       });
     });
 
-    const { fetchHandler } = await app.generate().onInit();
+    const { fetchHandler } = await app.generate().onStart();
 
     // Test with Accept: text/html
     const htmlRequest = new Request('http://localhost/', {
@@ -84,7 +84,7 @@ describe('Error Response JSON Only', () => {
     app.get('/notfound', (ctx) => ctx.res.notFound({ message: 'Resource not found' }));
     app.get('/internal', (ctx) => ctx.res.internalError({ message: 'Server error' }));
 
-    const { fetchHandler } = await app.generate().onInit();
+    const { fetchHandler } = await app.generate().onStart();
 
     const testCases = [
       { path: '/unauthorized', status: 401, type: 'UNAUTHORIZED' },
@@ -110,7 +110,7 @@ describe('Error Response JSON Only', () => {
       return ctx.res.badRequest(); // No options
     });
 
-    const { fetchHandler } = await app.generate().onInit();
+    const { fetchHandler } = await app.generate().onStart();
     const response = await fetchHandler(new Request('http://localhost/'));
     const body = await response.json();
 

--- a/packages/nodejs-adapter/src/node-server.ts
+++ b/packages/nodejs-adapter/src/node-server.ts
@@ -54,7 +54,7 @@ export async function startNodeServer<
   const hostname = options.hostname ?? 'localhost';
 
   const generated = kori.generate();
-  const { fetchHandler, onClose } = await generated.onInit();
+  const { fetchHandler, onClose } = await generated.onStart();
 
   const server = createAdaptorServer({
     fetch: fetchHandler,

--- a/packages/openapi-plugin/src/openapi-plugin.ts
+++ b/packages/openapi-plugin/src/openapi-plugin.ts
@@ -110,7 +110,7 @@ export function openApiPlugin<Env extends KoriEnvironment, Req extends KoriReque
         pluginMetadata: openApiMeta({ exclude: true }),
       });
 
-      return kori.onInit((ctx) => {
+      return kori.onStart((ctx) => {
         // Collect route metadata from the kori instance (after all routes are registered)
         const routeDefinitions = kori.routeDefinitions();
         for (const routeDef of routeDefinitions) {

--- a/packages/security-headers-plugin/src/security-headers-plugin.ts
+++ b/packages/security-headers-plugin/src/security-headers-plugin.ts
@@ -231,15 +231,18 @@ export function securityHeadersPlugin<Env extends KoriEnvironment, Req extends K
         skipPathsCount: skipPaths.length,
       });
 
-      return kori.onResponse((ctx) => {
-        const pathname = ctx.req.url().pathname;
+      return kori.onRequest((ctx) => {
+        // Defer security headers setting until after handler execution
+        ctx.defer((deferCtx) => {
+          const pathname = deferCtx.req.url().pathname;
 
-        // Skip security headers for specified paths
-        if (shouldSkipPath(pathname, skipPaths)) {
-          return;
-        }
+          // Skip security headers for specified paths
+          if (shouldSkipPath(pathname, skipPaths)) {
+            return;
+          }
 
-        setSecurityHeaders(ctx.res, options);
+          setSecurityHeaders(deferCtx.res, options);
+        });
       });
     },
   });


### PR DESCRIPTION
# Implement response abort and unified defer pattern

This PR introduces significant improvements to Kori's hook architecture and adds response abort functionality for better developer experience and type safety.

## 🚀 New Features

### Response Abort Functionality
- Early request termination with type-safe `KoriResponseAbortObject`
- `res.isAborted()` method to check abort status
- Automatic hook execution flow control respects abort state
- Type-safe abort handling with `KoriResponseAbort` type and `isKoriResponseAbort` guard

### Unified Defer Pattern
- New `ctx.defer()` method for both Handler Context and Instance Context
- LIFO (Last-In, First-Out) cleanup execution order
- Type-safe callbacks with proper context preservation
- Unified cleanup mechanism across request and application lifecycles

## 🔄 Breaking Changes

### Hook Architecture Simplification
- **Handlers**: 4-hook → 2-hook architecture (`onRequest`, `onError`)
- **Instances**: 2-hook → 1-hook architecture (`onStart`)
- Removed hooks: `onResponse`, `onFinally`, `onClose`
- Renamed: `onInit` → `onStart`

### Execution Flow Changes
- **Before**: `onRequest → Handler → onResponse → onFinally`
- **After**: `onRequest → Handler → defer callbacks (reverse order)`

## 🛠️ Migration Guide

### Hook Replacements
```typescript
// Before
app.onResponse(hook) → ctx.defer(callback) within onRequest
app.onFinally(hook) → ctx.defer(callback) within onRequest  
app.onInit(hook) → app.onStart(hook)
app.onClose(hook) → ctx.defer(callback) within onStart
```

### Example Migration
```typescript
// Before
app
  .onRequest((ctx) => { /* setup */ })
  .onResponse((ctx) => { /* response processing */ })
  .onFinally((ctx) => { /* cleanup */ })

// After  
app.onRequest((ctx) => {
  /* setup */
  ctx.defer((ctx) => { /* response processing */ });
  ctx.defer((ctx) => { /* cleanup */ });
})
```

## 💡 Benefits

1. **Simplified Architecture**: Fewer hooks, easier to understand
2. **Better Type Safety**: Removed `any` types, improved type inference
3. **Consistent API**: Unified defer pattern across contexts
4. **Performance**: Reduced overhead from unnecessary hook executions
5. **Developer Experience**: Clearer execution flow and better error handling

## 📦 Affected Packages

- `@korix/kori` - Core framework changes
- `@korix/cors-plugin` - Updated to use defer pattern
- `@korix/security-headers-plugin` - Updated to use defer pattern  
- `@korix/example` - Updated examples
- Documentation updates across all guides

## ✅ Quality Assurance

- All tests passing
- Type safety verified
- Linting and formatting applied
- Build successful across all packages
- Pre-commit hooks validated

This change sets the foundation for a more robust and developer-friendly framework while maintaining the core principles of type safety and performance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a unified deferred cleanup mechanism using `ctx.defer()`, allowing cleanup tasks to be registered and executed in reverse order after handlers complete.
  * Added response abort functionality, enabling early termination of requests and providing a method to check abort status.

* **Breaking Changes**
  * Removed and consolidated several lifecycle and handler hooks: `onInit` replaced by `onStart`, and `onClose`, `onResponse`, and `onFinally` hooks were removed.
  * Handler hooks are now limited to `onRequest` and `onError`, and instance lifecycle hooks to `onStart`.
  * Deferred cleanup and logging now use the new `ctx.defer()` pattern.

* **Bug Fixes**
  * Ensured that requests with invalid headers or preflight CORS requests are aborted immediately, preventing further processing.

* **Documentation**
  * Updated guides and API documentation to reflect the new lifecycle and deferred cleanup patterns, including revised examples and migration instructions.

* **Refactor**
  * Simplified internal logic and plugin implementations to use deferred callbacks for cleanup and side effects, improving consistency and maintainability.

* **Tests**
  * Updated tests to use the new `onStart` lifecycle hook in place of the removed `onInit` hook.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->