### PR TITLE
Extract OnRequestReturnValue type alias

### DIFF
--- a/packages/kori/src/hook/handler-hook.ts
+++ b/packages/kori/src/hook/handler-hook.ts
@@ -7,15 +7,21 @@ import {
 } from '../context/index.js';
 import { type MaybePromise } from '../util/index.js';
 
+export type OnRequestReturnValue<
+  Env extends KoriEnvironment,
+  Req extends KoriRequest,
+  Res extends KoriResponse,
+  ReqExt = unknown,
+  ResExt = unknown,
+> = KoriHandlerContext<Env, Req & ReqExt, Res & ResExt> | KoriResponseAbort | void;
+
 export type KoriOnRequestHook<
   Env extends KoriEnvironment,
   Req extends KoriRequest,
   Res extends KoriResponse,
   ReqExt = unknown,
   ResExt = unknown,
-> = (
-  ctx: KoriHandlerContext<Env, Req, Res>,
-) => MaybePromise<KoriHandlerContext<Env, Req & ReqExt, Res & ResExt> | KoriResponseAbort | void>;
+> = (ctx: KoriHandlerContext<Env, Req, Res>) => MaybePromise<OnRequestReturnValue<Env, Req, Res, ReqExt, ResExt>>;
 
 export type KoriOnErrorHook<Env extends KoriEnvironment, Req extends KoriRequest, Res extends KoriResponse> = (
   ctx: KoriHandlerContext<Env, Req, Res>,

--- a/packages/kori/src/hook/index.ts
+++ b/packages/kori/src/hook/index.ts
@@ -1,2 +1,2 @@
-export { type KoriOnErrorHook, type KoriOnRequestHook } from './handler-hook.js';
+export { type KoriOnErrorHook, type KoriOnRequestHook, type OnRequestReturnValue } from './handler-hook.js';
 export { type KoriOnStartHook } from './instance-hook.js';

--- a/packages/kori/src/index.ts
+++ b/packages/kori/src/index.ts
@@ -15,7 +15,12 @@ export {
 } from './context/index.js';
 export { type KoriError, type KoriValidationConfigError } from './error/index.js';
 export { type KoriFetchHandler, type KoriInitializedFetchHandler } from './fetch-handler/index.js';
-export { type KoriOnErrorHook, type KoriOnRequestHook, type KoriOnStartHook } from './hook/index.js';
+export {
+  type KoriOnErrorHook,
+  type KoriOnRequestHook,
+  type KoriOnStartHook,
+  type OnRequestReturnValue,
+} from './hook/index.js';
 export {
   ContentType,
   type ContentTypeValue,


### PR DESCRIPTION
## Summary

Extract `OnRequestReturnValue` type alias to improve readability of `KoriOnRequestHook` type definition.

## Changes

- Add `OnRequestReturnValue` type alias in `handler-hook.ts`
- Refactor `KoriOnRequestHook` to use the new type alias for better readability
- Export the new type alias from hook and main index files

## Motivation

The return type of `KoriOnRequestHook` was quite complex and long, making the type definition hard to read. By extracting it into a separate type alias, we improve code readability while maintaining the same functionality.

## Type of Change

- Code refactoring (no functional changes)
- Improved type definition readability