### PR TITLE
Fix OpenAPI path parameter conversion

### DIFF
--- a/.changeset/openapi-path-parameter-conversion.md
+++ b/.changeset/openapi-path-parameter-conversion.md
@@ -1,0 +1,9 @@
+---
+'@korix/openapi-plugin': patch
+---
+
+Fix OpenAPI path parameter conversion and automatic parameter extraction
+
+- Convert Hono-style path parameters (:param) to OpenAPI format ({param})
+- Automatically extract path parameters from route paths for OpenAPI documentation
+- Ensure all path parameters are properly included in OpenAPI parameters array


### PR DESCRIPTION
## Summary

Fix OpenAPI path parameter conversion and automatic parameter extraction.

## Changes

- **Path Parameter Conversion**: Convert Hono-style path parameters (`:param`) to OpenAPI format (`{param}`)
- **Automatic Parameter Extraction**: Extract path parameters from route paths and include them in OpenAPI documentation
- **Parameter Schema Support**: Use parameter schemas from `requestSchema.params` when available, fallback to string type

## Problem

Previously, OpenAPI documentation generated incorrect path formats:
- Hono routes: `/users/:id` 
- OpenAPI paths: `/users/:id` (incorrect)
- Parameters array: `[]` (empty)

## Solution

After this fix:
- Hono routes: `/users/:id`
- OpenAPI paths: `/users/{id}` (correct)
- Parameters array: `[{ name: "id", in: "path", required: true, schema: { type: "string" } }]`

## Technical Details

1. Added `convertHonoPathToOpenApiPath()` function to transform path format
2. Added `extractPathParameters()` function to extract parameter names from paths
3. Modified `generateParameters()` to automatically include path parameters
4. Parameter schemas are enhanced with `requestSchema.params` when available

## Testing

- All existing tests pass
- Linting and type checking pass
- Ready for deployment