### PR TITLE
Add pathTemplate method to KoriRequest

### DIFF
--- a/.changeset/add-path-template-method.md
+++ b/.changeset/add-path-template-method.md
@@ -1,0 +1,13 @@
+---
+'@korix/kori': patch
+---
+
+Add pathTemplate method to KoriRequest
+
+Add ability to retrieve the original path template (e.g., '/users/:id') from the request object. This is useful for logging, metrics collection, and debugging purposes.
+
+The new pathTemplate() method allows developers to access the route pattern that matched the request, which is particularly useful for:
+- Aggregating logs by route pattern instead of specific parameter values
+- Tracking API usage by endpoint pattern for metrics
+- Debugging route matching behavior
+- Implementing path template-based access control

--- a/packages/example/src/path-template-example.ts
+++ b/packages/example/src/path-template-example.ts
@@ -1,0 +1,31 @@
+import { createKori } from '@korix/kori';
+
+const app = createKori();
+
+app.get('/', (ctx) => {
+  return ctx.res.text(`Template: ${ctx.req.pathTemplate()}`);
+});
+
+app.get('/users/:id', (ctx) => {
+  return ctx.res.json({
+    template: ctx.req.pathTemplate(),
+    params: ctx.req.pathParams(),
+    message: `User ${ctx.req.pathParams().id}`,
+  });
+});
+
+app.get('/users/:id/posts/:postId', (ctx) => {
+  return ctx.res.json({
+    template: ctx.req.pathTemplate(),
+    params: ctx.req.pathParams(),
+    message: `Post ${ctx.req.pathParams().postId} by user ${ctx.req.pathParams().id}`,
+  });
+});
+
+// For testing purposes
+export default app;
+
+// Example usage:
+// GET / -> { template: "/" }
+// GET /users/123 -> { template: "/users/:id", params: { id: "123" } }
+// GET /users/123/posts/456 -> { template: "/users/:id/posts/:postId", params: { id: "123", postId: "456" } }

--- a/packages/kori/src/context/request.ts
+++ b/packages/kori/src/context/request.ts
@@ -17,6 +17,7 @@ export type KoriRequest = {
   url(): URL;
   method(): string;
   pathParams(): Record<string, string>;
+  pathTemplate(): string;
   queryParams(): Record<string, string | string[]>;
 
   headers(): Record<string, string>;
@@ -47,6 +48,7 @@ type ReqState = {
   [KoriRequestBrand]: typeof KoriRequestBrand;
   raw: Request;
   pathParamsData: Record<string, string>;
+  pathTemplateData: string;
   bodyCache: BodyCache;
   clonedRawRequest?: Request;
   urlCache?: URL;
@@ -68,6 +70,10 @@ function getMethodInternal(req: ReqState): string {
 
 function getPathParamsInternal(req: ReqState): Record<string, string> {
   return req.pathParamsData;
+}
+
+function getPathTemplateInternal(req: ReqState): string {
+  return req.pathTemplateData;
 }
 
 function getQueryParamsInternal(req: ReqState): Record<string, string | string[]> {
@@ -193,6 +199,9 @@ const sharedMethods = {
   pathParams(): Record<string, string> {
     return getPathParamsInternal(this);
   },
+  pathTemplate(): string {
+    return getPathTemplateInternal(this);
+  },
   queryParams(): Record<string, string | string[]> {
     return getQueryParamsInternal(this);
   },
@@ -241,15 +250,18 @@ const sharedMethods = {
 export function createKoriRequest({
   rawRequest,
   pathParams,
+  pathTemplate,
 }: {
   rawRequest: Request;
   pathParams: Record<string, string>;
+  pathTemplate: string;
 }): KoriRequest {
   const obj = Object.create(sharedMethods) as ReqState;
 
   obj[KoriRequestBrand] = KoriRequestBrand;
   obj.raw = rawRequest;
   obj.pathParamsData = pathParams;
+  obj.pathTemplateData = pathTemplate;
   obj.bodyCache = {};
   return obj as unknown as KoriRequest;
 }

--- a/packages/kori/src/kori/fetch-handler-factory.ts
+++ b/packages/kori/src/kori/fetch-handler-factory.ts
@@ -43,6 +43,7 @@ export function createFetchHandler({
       const req = createKoriRequest({
         rawRequest: request,
         pathParams: routeResult.pathParams,
+        pathTemplate: routeResult.pathTemplate,
       });
 
       const handlerCtx = createKoriHandlerContext({

--- a/packages/kori/src/router/hono-router-adapter.ts
+++ b/packages/kori/src/router/hono-router-adapter.ts
@@ -51,11 +51,15 @@ export function createHonoRouter(): KoriRouter {
     routers: [new RegExpRouter(), new TrieRouter()],
   });
 
+  // Store path templates for each handler
+  const handlerToPathTemplate = new Map<KoriRouterHandlerAny, string>();
+
   return {
     addRoute: <Env extends KoriEnvironment, Req extends KoriRequest, Res extends KoriResponse, Path extends string>(
       options: KoriRouteOptions<Env, Req, Res, Path>,
     ) => {
       router.add(options.method, options.path, options.handler);
+      handlerToPathTemplate.set(options.handler, options.path);
     },
 
     compile: (): KoriCompiledRouter => {
@@ -70,9 +74,11 @@ export function createHonoRouter(): KoriRouter {
         }
 
         const pathParams = convertParams(matched);
+        const pathTemplate = handlerToPathTemplate.get(handler) ?? '';
         return {
           handler,
           pathParams,
+          pathTemplate,
         };
       };
     },

--- a/packages/kori/src/router/router.ts
+++ b/packages/kori/src/router/router.ts
@@ -26,6 +26,7 @@ export type KoriRouteOptions<
 export type KoriRoutingMatch = {
   handler: KoriRouterHandler<KoriEnvironment, KoriRequest, KoriResponse>;
   pathParams: Record<string, string>;
+  pathTemplate: string;
 };
 
 export type KoriCompiledRouter = (request: Request) => KoriRoutingMatch | undefined;


### PR DESCRIPTION
## Add pathTemplate method to KoriRequest

This PR adds the ability to retrieve the original path template (e.g., `/users/:id`) from the request object, which is useful for logging, metrics collection, and debugging purposes.

### Changes

- **Add `pathTemplate()` method to KoriRequest interface**: Allows accessing the original route template
- **Extend KoriRoutingMatch to include pathTemplate field**: Router now returns path template along with handler and params
- **Store path templates in router using Map for O(1) lookup**: Efficient implementation using handler-to-template mapping
- **Add path template example usage**: Demonstrates practical usage patterns

### Usage

```typescript
app.get('/users/:id/posts/:postId', (ctx) => {
  console.log(ctx.req.pathTemplate()); // "/users/:id/posts/:postId"
  console.log(ctx.req.pathParams());   // { id: "123", postId: "456" }
  
  // Perfect for logging and metrics
  ctx.log().info('API called', {
    template: ctx.req.pathTemplate(),
    params: ctx.req.pathParams(),
  });
});
```

### Benefits

- **Logging**: Aggregate logs by route pattern instead of specific parameter values
- **Metrics collection**: Track API usage by endpoint pattern
- **Debugging**: Easily identify which route pattern matched the request
- **Authorization**: Enable path template-based access control

### Implementation Details

The implementation uses a `Map<Handler, string>` to store the mapping between route handlers and their corresponding path templates. This provides O(1) lookup performance while keeping the router.match() operation efficient.

We explored using `router.match()` results directly, but Hono's router only returns the handler and parameter information for performance reasons, making our Map-based approach the optimal solution.