### PR TITLE
Framework v0.2.0 - Architecture redesign with unified changeset

### DIFF
--- a/.changeset/framework-architecture-redesign.md
+++ b/.changeset/framework-architecture-redesign.md
@@ -8,6 +8,11 @@
 '@korix/security-headers-plugin': minor
 '@korix/zod-schema': minor
 '@korix/zod-validator': minor
+'@korix/logtape-log-reporter': minor
+'@korix/openapi-scalar-ui-plugin': minor
+'@korix/pino-log-reporter': minor
+'@korix/zod-openapi-plugin': minor
+'@korix/eslint-config': minor
 ---
 
 Framework architecture redesign and API improvements

--- a/patches/@changesets__assemble-release-plan@6.0.9.patch
+++ b/patches/@changesets__assemble-release-plan@6.0.9.patch
@@ -1,0 +1,30 @@
+diff --git a/dist/changesets-assemble-release-plan.cjs.js b/dist/changesets-assemble-release-plan.cjs.js
+index e07ba6e793021b6cfdec898afca517e293386ddb..bbd48651858f6d53f57701c2d151a1bcafb977e5 100644
+--- a/dist/changesets-assemble-release-plan.cjs.js
++++ b/dist/changesets-assemble-release-plan.cjs.js
+@@ -317,6 +317,10 @@ function shouldBumpMajor({
+   preInfo,
+   onlyUpdatePeerDependentsWhenOutOfRange
+ }) {
++  if (depType === "peerDependencies") {
++    return false;
++  }
++
+   // we check if it is a peerDependency because if it is, our dependent bump type might need to be major.
+   return depType === "peerDependencies" && nextRelease.type !== "none" && nextRelease.type !== "patch" && (
+   // 1. If onlyUpdatePeerDependentsWhenOutOfRange set to true, bump major if the version is leaving the range.
+diff --git a/dist/changesets-assemble-release-plan.esm.js b/dist/changesets-assemble-release-plan.esm.js
+index ea2be567403c4ef94a65f3218ccb683cf5cb4bc1..5e9fc1d8008e4d9a4389bf6f8b136ddf1ede3185 100644
+--- a/dist/changesets-assemble-release-plan.esm.js
++++ b/dist/changesets-assemble-release-plan.esm.js
+@@ -306,6 +306,10 @@ function shouldBumpMajor({
+   preInfo,
+   onlyUpdatePeerDependentsWhenOutOfRange
+ }) {
++  if (depType === "peerDependencies") {
++    return false;
++  }
++
+   // we check if it is a peerDependency because if it is, our dependent bump type might need to be major.
+   return depType === "peerDependencies" && nextRelease.type !== "none" && nextRelease.type !== "patch" && (
+   // 1. If onlyUpdatePeerDependentsWhenOutOfRange set to true, bump major if the version is leaving the range.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,11 @@ catalogs:
       specifier: 3.2.4
       version: 3.2.4
 
+patchedDependencies:
+  '@changesets/assemble-release-plan@6.0.9':
+    hash: aca8817828492f0ffb24c7308fe56e19181664dc8dea1185583309614b374eeb
+    path: patches/@changesets__assemble-release-plan@6.0.9.patch
+
 importers:
 
   .:
@@ -4185,7 +4190,7 @@ snapshots:
       resolve-from: 5.0.0
       semver: 7.7.2
 
-  '@changesets/assemble-release-plan@6.0.9':
+  '@changesets/assemble-release-plan@6.0.9(patch_hash=aca8817828492f0ffb24c7308fe56e19181664dc8dea1185583309614b374eeb)':
     dependencies:
       '@changesets/errors': 0.2.0
       '@changesets/get-dependents-graph': 2.1.3
@@ -4201,7 +4206,7 @@ snapshots:
   '@changesets/cli@2.29.5':
     dependencies:
       '@changesets/apply-release-plan': 7.0.12
-      '@changesets/assemble-release-plan': 6.0.9
+      '@changesets/assemble-release-plan': 6.0.9(patch_hash=aca8817828492f0ffb24c7308fe56e19181664dc8dea1185583309614b374eeb)
       '@changesets/changelog-git': 0.2.1
       '@changesets/config': 3.1.1
       '@changesets/errors': 0.2.0
@@ -4252,7 +4257,7 @@ snapshots:
 
   '@changesets/get-release-plan@4.0.13':
     dependencies:
-      '@changesets/assemble-release-plan': 6.0.9
+      '@changesets/assemble-release-plan': 6.0.9(patch_hash=aca8817828492f0ffb24c7308fe56e19181664dc8dea1185583309614b374eeb)
       '@changesets/config': 3.1.1
       '@changesets/pre': 2.0.2
       '@changesets/read': 0.6.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,10 +1,13 @@
 packages:
-  - 'packages/*'
+  - packages/*
 
 catalog:
-  rimraf: '6.0.1'
-  typescript: '5.8.3'
-  '@types/node': '20.11.17'
-  eslint: '9.16.0'
-  tsdown: '0.12.9'
-  vitest: '3.2.4'
+  '@types/node': 20.11.17
+  eslint: 9.16.0
+  rimraf: 6.0.1
+  tsdown: 0.12.9
+  typescript: 5.8.3
+  vitest: 3.2.4
+
+patchedDependencies:
+  '@changesets/assemble-release-plan@6.0.9': patches/@changesets__assemble-release-plan@6.0.9.patch


### PR DESCRIPTION
Unified changeset for v0.2.0 release across all packages with framework architecture redesign.

All packages will be bumped to 0.2.0 with this release.

**Changeset Status:**
- All 14 packages: minor version bump (0.1.2 → 0.2.0)
- No major version changes
- Comprehensive framework architecture improvements

See changeset file for detailed changes.