### PR TITLE
Check real timer safety with errors

### DIFF
--- a/packages/kori/tests/logging/logger.test.ts
+++ b/packages/kori/tests/logging/logger.test.ts
@@ -28,22 +28,25 @@ describe('KoriLogger', () => {
     test('should create complete log entry', () => {
       const fixedTime = 1640995200000; // 2022-01-01 00:00:00 UTC
       vi.useFakeTimers();
-      vi.setSystemTime(fixedTime);
 
-      logger.info('Test message');
+      try {
+        vi.setSystemTime(fixedTime);
 
-      expect(mockReporter).toHaveBeenCalledTimes(1);
-      const logEntry: KoriLogEntry = mockReporter.mock.calls[0]?.[0];
+        logger.info('Test message');
 
-      expect(logEntry).toEqual({
-        time: fixedTime,
-        level: 'info',
-        channel: 'test',
-        name: 'logger',
-        message: 'Test message',
-      });
+        expect(mockReporter).toHaveBeenCalledTimes(1);
+        const logEntry: KoriLogEntry = mockReporter.mock.calls[0]?.[0];
 
-      vi.useRealTimers();
+        expect(logEntry).toEqual({
+          time: fixedTime,
+          level: 'info',
+          channel: 'test',
+          name: 'logger',
+          message: 'Test message',
+        });
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     test('should include meta when provided', () => {


### PR DESCRIPTION
Wrap fake timer usage in a `try-finally` block to ensure `vi.useRealTimers()` is always called, preventing fake timers from leaking into other tests.

---
<a href="https://cursor.com/background-agent?bcId=bc-6ad26303-89c4-4f3f-87c3-2b22df917565">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6ad26303-89c4-4f3f-87c3-2b22df917565">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

