### PR TITLE
Console reporter refactoring and Node.js adapter URL improvements

### DIFF
--- a/.changeset/nodejs-adapter-url-display-fix.md
+++ b/.changeset/nodejs-adapter-url-display-fix.md
@@ -1,0 +1,10 @@
+---
+"@korix/nodejs-adapter": patch
+---
+
+Fix URL display in Node.js adapter to show user-friendly URLs instead of IPv6 addresses.
+
+- Use user-specified hostname instead of actual bind address for display
+- Convert special addresses (0.0.0.0, ::, ::1) to 'localhost' for better readability
+- Inspired by Fastify's approach for improved developer experience
+- Now shows `http://localhost:3001` instead of `http://[::1]:3001` when using localhost

--- a/packages/kori/src/logging/console-reporter-presets.ts
+++ b/packages/kori/src/logging/console-reporter-presets.ts
@@ -1,24 +1,17 @@
-import { type KoriLogEntry } from './log-entry.js';
+import { type KoriLogFilter } from './log-filter.js';
 import { createJsonFormatter, createPrettyFormatter } from './log-formatter.js';
 import { type KoriLogReporter } from './log-reporter.js';
 
 /**
- * Pre-configured console reporter presets for common use cases.
+ * Structured JSON output to console.
+ * Suitable for production, CI, and log aggregation systems.
+ *
+ * @param options - Configuration options
+ * @param options.filter - Optional filter to control which entries are logged
+ * @returns Reporter configured for JSON console output
  */
-export const KoriConsoleReporterPresets = {
-  /**
-   * Structured JSON output to console.
-   * Suitable for production, CI, and log aggregation systems.
-   *
-   * @param options - Configuration options
-   * @param options.filter - Optional filter to control which entries are logged
-   * @returns Reporter configured for JSON console output
-   */
-  json: (
-    options: {
-      filter?: (entry: KoriLogEntry) => boolean;
-    } = {},
-  ): KoriLogReporter => ({
+export function jsonConsoleReporter(options: { filter?: KoriLogFilter } = {}): KoriLogReporter {
+  return {
     filter: options.filter,
     sinks: [
       {
@@ -34,23 +27,20 @@ export const KoriConsoleReporterPresets = {
         },
       },
     ],
-  }),
+  };
+}
 
-  /**
-   * Human-readable colored output to console.
-   * Ideal for development and debugging.
-   *
-   * @param options - Configuration options
-   * @param options.colorize - Enable ANSI colors for log levels (default: true)
-   * @param options.filter - Optional filter to control which entries are logged
-   * @returns Reporter configured for pretty console output
-   */
-  pretty: (
-    options: {
-      colorize?: boolean;
-      filter?: (entry: KoriLogEntry) => boolean;
-    } = {},
-  ): KoriLogReporter => ({
+/**
+ * Human-readable colored output to console.
+ * Ideal for development and debugging.
+ *
+ * @param options - Configuration options
+ * @param options.colorize - Enable ANSI colors for log levels (default: true)
+ * @param options.filter - Optional filter to control which entries are logged
+ * @returns Reporter configured for pretty console output
+ */
+export function prettyConsoleReporter(options: { colorize?: boolean; filter?: KoriLogFilter } = {}): KoriLogReporter {
+  return {
     filter: options.filter,
     sinks: [
       {
@@ -68,14 +58,23 @@ export const KoriConsoleReporterPresets = {
         },
       },
     ],
-  }),
+  };
+}
 
-  /**
-   * No output. Useful for testing or when logging is disabled.
-   *
-   * @returns Reporter configured to suppress all output
-   */
-  silent: (): KoriLogReporter => ({
-    sinks: [],
-  }),
+/**
+ * No output. Useful for testing or when logging is disabled.
+ *
+ * @returns Reporter configured to suppress all output
+ */
+export function silentConsoleReporter(): KoriLogReporter {
+  return { sinks: [] };
+}
+
+/**
+ * Pre-configured console reporter presets for common use cases.
+ */
+export const KoriConsoleReporterPresets = {
+  json: jsonConsoleReporter,
+  pretty: prettyConsoleReporter,
+  silent: silentConsoleReporter,
 } as const;

--- a/packages/kori/tests/logging/console-reporter-presets.test.ts
+++ b/packages/kori/tests/logging/console-reporter-presets.test.ts
@@ -1,191 +1,195 @@
 import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
 
-import { KoriConsoleReporterPresets } from '../../src/logging/console-reporter-presets.js';
+import {
+  jsonConsoleReporter,
+  prettyConsoleReporter,
+  silentConsoleReporter,
+  KoriConsoleReporterPresets,
+} from '../../src/logging/console-reporter-presets.js';
 import { type KoriLogEntry } from '../../src/logging/log-entry.js';
 
+let mockConsoleLog: ReturnType<typeof vi.spyOn>;
+let mockConsoleError: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  mockConsoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+  mockConsoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('jsonConsoleReporter', () => {
+  test('should output info logs to console.log as JSON', () => {
+    const reporter = jsonConsoleReporter();
+    const logEntry: KoriLogEntry = {
+      time: 1640995200000,
+      level: 'info',
+      channel: 'app',
+      name: 'server',
+      message: 'Test message',
+      meta: { userId: 'user-123' },
+    };
+
+    void reporter.sinks[0]?.write(reporter.sinks[0]?.formatter(logEntry), logEntry);
+
+    expect(mockConsoleLog).toHaveBeenCalledTimes(1);
+    const output = mockConsoleLog.mock.calls[0]?.[0];
+    expect(output).toContain('"message":"Test message"');
+    expect(output).toContain('"level":"info"');
+  });
+
+  test('should output error logs to console.error as JSON', () => {
+    const reporter = jsonConsoleReporter();
+    const logEntry: KoriLogEntry = {
+      time: 1640995200000,
+      level: 'error',
+      channel: 'app',
+      name: 'server',
+      message: 'Error message',
+    };
+
+    void reporter.sinks[0]?.write(reporter.sinks[0]?.formatter(logEntry), logEntry);
+
+    expect(mockConsoleError).toHaveBeenCalledTimes(1);
+    const output = mockConsoleError.mock.calls[0]?.[0];
+    expect(output).toContain('"message":"Error message"');
+    expect(output).toContain('"level":"error"');
+  });
+
+  test('should apply custom filter correctly', () => {
+    const reporter = jsonConsoleReporter({
+      filter: (entry) => entry.channel === 'app',
+    });
+
+    const appEntry: KoriLogEntry = {
+      time: 1640995200000,
+      level: 'info',
+      channel: 'app',
+      name: 'handler',
+      message: 'Should pass through',
+    };
+
+    const sysEntry: KoriLogEntry = {
+      time: 1640995200000,
+      level: 'error',
+      channel: 'sys',
+      name: 'core',
+      message: 'Should be filtered out',
+    };
+
+    expect(reporter.filter?.(appEntry)).toBe(true);
+    expect(reporter.filter?.(sysEntry)).toBe(false);
+  });
+});
+
+describe('prettyConsoleReporter', () => {
+  test('should output human-readable format with colors enabled by default', () => {
+    const reporter = prettyConsoleReporter();
+    const logEntry: KoriLogEntry = {
+      time: 1640995200000,
+      level: 'info',
+      channel: 'app',
+      name: 'server',
+      message: 'Pretty test',
+    };
+
+    void reporter.sinks[0]?.write(reporter.sinks[0]?.formatter(logEntry), logEntry);
+
+    expect(mockConsoleLog).toHaveBeenCalledTimes(1);
+    const output = mockConsoleLog.mock.calls[0]?.[0];
+    expect(output).toContain('Pretty test');
+    expect(output).toContain('[app:server]');
+    expect(output).toContain('INFO ');
+  });
+
+  test('should support colorize option with actual color output differences', () => {
+    const colorizedReporter = prettyConsoleReporter({ colorize: true });
+    const nonColorizedReporter = prettyConsoleReporter({ colorize: false });
+
+    const logEntry: KoriLogEntry = {
+      time: 1640995200000,
+      level: 'warn',
+      channel: 'app',
+      name: 'test',
+      message: 'Warning message',
+    };
+
+    const colorizedOutput = colorizedReporter.sinks[0]?.formatter(logEntry);
+    const nonColorizedOutput = nonColorizedReporter.sinks[0]?.formatter(logEntry);
+
+    // Colorized should contain ANSI escape codes
+    expect(colorizedOutput).toContain('\x1b[33m'); // Yellow for warn
+    expect(colorizedOutput).toContain('\x1b[0m'); // Reset
+
+    // Non-colorized should not contain ANSI codes
+    expect(nonColorizedOutput).not.toContain('\x1b[');
+
+    // Both should contain the same basic content
+    expect(colorizedOutput).toContain('WARN ');
+    expect(nonColorizedOutput).toContain('WARN ');
+    expect(colorizedOutput).toContain('[app:test]');
+    expect(nonColorizedOutput).toContain('[app:test]');
+  });
+
+  test('should output error logs to console.error', () => {
+    const reporter = prettyConsoleReporter();
+    const logEntry: KoriLogEntry = {
+      time: 1640995200000,
+      level: 'fatal',
+      channel: 'sys',
+      name: 'core',
+      message: 'Fatal error',
+    };
+
+    void reporter.sinks[0]?.write(reporter.sinks[0]?.formatter(logEntry), logEntry);
+
+    expect(mockConsoleError).toHaveBeenCalledTimes(1);
+    const output = mockConsoleError.mock.calls[0]?.[0];
+    expect(output).toContain('Fatal error');
+    expect(output).toContain('[sys:core]');
+  });
+
+  test('should apply custom filter correctly', () => {
+    const reporter = prettyConsoleReporter({
+      filter: (entry) => entry.channel === 'app',
+    });
+
+    const appEntry: KoriLogEntry = {
+      time: 1640995200000,
+      level: 'info',
+      channel: 'app',
+      name: 'handler',
+      message: 'Should pass through',
+    };
+
+    const sysEntry: KoriLogEntry = {
+      time: 1640995200000,
+      level: 'error',
+      channel: 'sys',
+      name: 'core',
+      message: 'Should be filtered out',
+    };
+
+    expect(reporter.filter?.(appEntry)).toBe(true);
+    expect(reporter.filter?.(sysEntry)).toBe(false);
+  });
+});
+
+describe('silentConsoleReporter', () => {
+  test('should not output anything to console', () => {
+    const reporter = silentConsoleReporter();
+
+    // Contract: silent reporter has no sinks to execute
+    expect(reporter.sinks).toHaveLength(0);
+  });
+});
+
 describe('KoriConsoleReporterPresets', () => {
-  let mockConsoleLog: ReturnType<typeof vi.spyOn>;
-  let mockConsoleError: ReturnType<typeof vi.spyOn>;
-
-  beforeEach(() => {
-    mockConsoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
-    mockConsoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  describe('json preset', () => {
-    test('should output info logs to console.log as JSON', () => {
-      const reporter = KoriConsoleReporterPresets.json();
-      const logEntry: KoriLogEntry = {
-        time: 1640995200000,
-        level: 'info',
-        channel: 'app',
-        name: 'server',
-        message: 'Test message',
-        meta: { userId: 'user-123' },
-      };
-
-      reporter.sinks[0]?.formatter(logEntry);
-      void reporter.sinks[0]?.write(reporter.sinks[0].formatter(logEntry), logEntry);
-
-      expect(mockConsoleLog).toHaveBeenCalledTimes(1);
-      const output = mockConsoleLog.mock.calls[0]?.[0];
-      expect(output).toContain('"message":"Test message"');
-      expect(output).toContain('"level":"info"');
-    });
-
-    test('should output error logs to console.error as JSON', () => {
-      const reporter = KoriConsoleReporterPresets.json();
-      const logEntry: KoriLogEntry = {
-        time: 1640995200000,
-        level: 'error',
-        channel: 'app',
-        name: 'server',
-        message: 'Error message',
-      };
-
-      void reporter.sinks[0]?.write(reporter.sinks[0]?.formatter(logEntry), logEntry);
-
-      expect(mockConsoleError).toHaveBeenCalledTimes(1);
-      const output = mockConsoleError.mock.calls[0]?.[0];
-      expect(output).toContain('"message":"Error message"');
-      expect(output).toContain('"level":"error"');
-    });
-
-    test('should apply custom filter correctly', () => {
-      const reporter = KoriConsoleReporterPresets.json({
-        filter: (entry) => entry.channel === 'app',
-      });
-
-      const appEntry: KoriLogEntry = {
-        time: 1640995200000,
-        level: 'info',
-        channel: 'app',
-        name: 'handler',
-        message: 'Should pass through',
-      };
-
-      const sysEntry: KoriLogEntry = {
-        time: 1640995200000,
-        level: 'error',
-        channel: 'sys',
-        name: 'core',
-        message: 'Should be filtered out',
-      };
-
-      // Test actual filter behavior
-      expect(reporter.filter?.(appEntry)).toBe(true);
-      expect(reporter.filter?.(sysEntry)).toBe(false);
-    });
-  });
-
-  describe('pretty preset', () => {
-    test('should output human-readable format with colors enabled by default', () => {
-      const reporter = KoriConsoleReporterPresets.pretty();
-      const logEntry: KoriLogEntry = {
-        time: 1640995200000,
-        level: 'info',
-        channel: 'app',
-        name: 'server',
-        message: 'Pretty test',
-      };
-
-      void reporter.sinks[0]?.write(reporter.sinks[0]?.formatter(logEntry), logEntry);
-
-      expect(mockConsoleLog).toHaveBeenCalledTimes(1);
-      const output = mockConsoleLog.mock.calls[0]?.[0];
-      expect(output).toContain('Pretty test');
-      expect(output).toContain('[app:server]');
-      expect(output).toContain('INFO ');
-    });
-
-    test('should support colorize option with actual color output differences', () => {
-      const colorizedReporter = KoriConsoleReporterPresets.pretty({ colorize: true });
-      const nonColorizedReporter = KoriConsoleReporterPresets.pretty({ colorize: false });
-
-      const logEntry: KoriLogEntry = {
-        time: 1640995200000,
-        level: 'warn',
-        channel: 'app',
-        name: 'test',
-        message: 'Warning message',
-      };
-
-      const colorizedOutput = colorizedReporter.sinks[0]?.formatter(logEntry);
-      const nonColorizedOutput = nonColorizedReporter.sinks[0]?.formatter(logEntry);
-
-      // Colorized should contain ANSI escape codes
-      expect(colorizedOutput).toContain('\x1b[33m'); // Yellow for warn
-      expect(colorizedOutput).toContain('\x1b[0m'); // Reset
-
-      // Non-colorized should not contain ANSI codes
-      expect(nonColorizedOutput).not.toContain('\x1b[');
-
-      // Both should contain the same basic content
-      expect(colorizedOutput).toContain('WARN ');
-      expect(nonColorizedOutput).toContain('WARN ');
-      expect(colorizedOutput).toContain('[app:test]');
-      expect(nonColorizedOutput).toContain('[app:test]');
-    });
-
-    test('should output error logs to console.error', () => {
-      const reporter = KoriConsoleReporterPresets.pretty();
-      const logEntry: KoriLogEntry = {
-        time: 1640995200000,
-        level: 'fatal',
-        channel: 'sys',
-        name: 'core',
-        message: 'Fatal error',
-      };
-
-      void reporter.sinks[0]?.write(reporter.sinks[0]?.formatter(logEntry), logEntry);
-
-      expect(mockConsoleError).toHaveBeenCalledTimes(1);
-      const output = mockConsoleError.mock.calls[0]?.[0];
-      expect(output).toContain('Fatal error');
-      expect(output).toContain('[sys:core]');
-    });
-
-    test('should apply custom filter correctly', () => {
-      const reporter = KoriConsoleReporterPresets.pretty({
-        filter: (entry) => entry.channel === 'app',
-      });
-
-      const appEntry: KoriLogEntry = {
-        time: 1640995200000,
-        level: 'info',
-        channel: 'app',
-        name: 'handler',
-        message: 'Should pass through',
-      };
-
-      const sysEntry: KoriLogEntry = {
-        time: 1640995200000,
-        level: 'error',
-        channel: 'sys',
-        name: 'core',
-        message: 'Should be filtered out',
-      };
-
-      // Test actual filter behavior
-      expect(reporter.filter?.(appEntry)).toBe(true);
-      expect(reporter.filter?.(sysEntry)).toBe(false);
-    });
-  });
-
-  describe('silent preset', () => {
-    test('should not output anything to console', () => {
-      const reporter = KoriConsoleReporterPresets.silent();
-
-      // Silent preset should produce no console output
-      expect(mockConsoleLog).not.toHaveBeenCalled();
-      expect(mockConsoleError).not.toHaveBeenCalled();
-
-      // Contract: silent reporter has no sinks to execute
-      expect(reporter.sinks).toHaveLength(0);
-    });
+  test('should reference the correct reporter functions', () => {
+    expect(KoriConsoleReporterPresets.json).toBe(jsonConsoleReporter);
+    expect(KoriConsoleReporterPresets.pretty).toBe(prettyConsoleReporter);
+    expect(KoriConsoleReporterPresets.silent).toBe(silentConsoleReporter);
   });
 });

--- a/packages/nodejs-adapter/src/node-server.ts
+++ b/packages/nodejs-adapter/src/node-server.ts
@@ -69,9 +69,13 @@ export async function startNodeServer<
 
     const address = server.address();
     if (address && typeof address !== 'string') {
-      const actualHost = address.address;
       const actualPort = address.port;
-      const displayHost = address.family === 'IPv6' ? `[${actualHost}]` : actualHost;
+
+      // Fastify-style user-friendly URL display
+      let displayHost = hostname;
+      if (hostname === '0.0.0.0' || hostname === '::' || hostname === '::1') {
+        displayHost = 'localhost';
+      }
 
       log.info(`Kori server started at http://${displayHost}:${actualPort}`);
     } else if (address && typeof address === 'string') {


### PR DESCRIPTION
## 🔧 Refactor: Console Reporters + Node.js Adapter URL Display Fix

This PR contains two improvements: refactoring console reporters to follow workspace coding standards and fixing URL display in the Node.js adapter for better developer experience.

### 🎯 Changes

#### 1. Console Reporter Refactoring
- **Function Declarations**: Changed console reporters from arrow functions to function declarations to comply with workspace rule "Public APIs should use function declarations"
- **Type Consistency**: Use existing `KoriLogFilter` type instead of inline `(entry: KoriLogEntry) => boolean` definition
- **Direct Export**: Export `jsonConsoleReporter`, `prettyConsoleReporter`, and `silentConsoleReporter` as named functions
- **Test Structure**: Reorganized tests to directly test individual reporter functions with a separate test for preset configuration

#### 2. Node.js Adapter URL Display Fix
- **User-Friendly URLs**: Display user-specified hostname instead of actual bind address
- **Special Address Handling**: Convert `0.0.0.0`, `::`, and `::1` to `localhost` for better readability
- **Improved DX**: Show `http://localhost:3001` instead of `http://[::1]:3001` when using localhost
- **Fastify-Inspired**: Following established patterns for better developer experience

### 🚀 Benefits

- **Better Code Quality**: Console reporters follow established workspace coding standards
- **Improved Maintainability**: Individual functions can be tested, modified, and extended independently
- **Enhanced Developer Experience**: Cleaner server startup URLs that are easier to click/copy
- **No Breaking Changes**: All existing APIs continue to work perfectly
- **Enhanced Flexibility**: Developers can now import reporter functions directly

### 📋 API Changes

**New Exports** (additive, non-breaking):
```typescript
import {
  jsonConsoleReporter,
  prettyConsoleReporter,
  silentConsoleReporter,
} from "@korix/kori";
```

**Existing API** (unchanged):
```typescript
import { KoriConsoleReporterPresets } from "@korix/kori";
// Still works exactly the same
const reporter = KoriConsoleReporterPresets.json({ filter: ... });
```

### 📊 File Changes

- **4 files changed**: 227 insertions(+), 210 deletions(-)
- **Console Reporter Source**: Complete refactoring with function declarations
- **Console Reporter Tests**: 9 tests (up from 8) with improved structure  
- **Node.js Adapter**: URL display logic improvement
- **Changeset**: Documentation for Node.js adapter fix

### ✅ Testing

- **All tests passing**: Console reporter tests reorganized and enhanced
- **Pre-commit hooks passing**: format, lint, typecheck all successful
- **Full build successful** across all packages
- **No breaking changes**: Existing APIs work identically

---

This change aligns the codebase with established patterns while improving developer experience across both logging and server startup.
