### PR TITLE
Fix TSDoc example and cleanup changeset

### DIFF
--- a/.changeset/result-api-refactor.md
+++ b/.changeset/result-api-refactor.md
@@ -1,6 +1,5 @@
 ---
 '@korix/kori': patch
-'@korix/zod-validator': patch
 ---
 
 Refactor Result API with clearer naming and consistency
@@ -16,20 +15,3 @@ This change improves the Result type API with more intuitive naming:
 
 - `ok()` → `succeed()`
 - `err()` → `fail()`
-
-**Validation failure types:**
-
-- `ValidationError` → `ValidationFailureReason`
-- `RequestValidationError` → `RequestValidationFailureReason`
-- `ResponseValidationError` → `ResponseValidationFailureReason`
-
-**Media type properties:**
-
-- `supportedTypes` → `supportedMediaTypes`
-- `requestType` → `requestMediaType`
-- `responseType` → `responseMediaType`
-
-This provides a more consistent and intuitive API across the framework.
-
-**Migration Guide:**
-Update all Result handling code to use the new property names and factory functions.

--- a/packages/kori/src/kori/kori-creator.ts
+++ b/packages/kori/src/kori/kori-creator.ts
@@ -25,8 +25,8 @@ import { type Kori } from './kori.js';
  *
  * // With validation
  * const app = createKori({
- *   requestValidation: enableMyRequestValidation(),
- *   responseValidation: enableMyResponseValidation(),
+ *   requestValidator: myRequestValidator,
+ *   responseValidator: myResponseValidator,
  *   loggerOptions: { level: 'warn' }
  * });
  * ```

--- a/temp_commit_msg.txt
+++ b/temp_commit_msg.txt
@@ -1,7 +1,0 @@
-Refactor schema architecture with new adapter system
-
-- Remove zod-schema and zod-validator packages
-- Add standard-schema-adapter and zod-schema-adapter packages
-- Update type system with improved provider constraints
-- Enhance schema validation with cleaner separation
-- Upgrade dependencies including Hono to latest version


### PR DESCRIPTION
Fix TSDoc example and cleanup changeset

## Changes

### TSDoc Example Update
- Updated `createKori` function example in TSDoc to use current API
- Changed `requestValidation` → `requestValidator`
- Changed `responseValidation` → `responseValidator`

### Changeset Cleanup
- Removed outdated `@korix/zod-validator` package reference from result-api-refactor changeset
- The zod-validator package was already removed but still referenced in the changeset

### File Cleanup
- Removed temporary commit message file

## Context

The TSDoc example was using the old API syntax that no longer exists in the current implementation. The `CreateKoriOptions` type now uses `requestValidator` and `responseValidator` properties instead of the previous validation naming convention.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Refactor
  * Renamed Result API: ok → success, error → reason; ok() → succeed(), err() → fail().
  * Migrated schema validation to an adapter-based approach; adjusted public types/exports accordingly.
* Documentation
  * Updated examples to use requestValidator/responseValidator.
* Chores
  * Removed peer dependency on '@korix/zod-validator'.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->