### PR TITLE
Allow access to parent path parameters via index signature

### DIFF
--- a/packages/kori/src/routing/path-params.ts
+++ b/packages/kori/src/routing/path-params.ts
@@ -56,6 +56,7 @@ export type PathParams<Path extends string> = string extends Path
  *
  * Replaces the generic `pathParams()` method with a type-safe version
  * that returns parameters extracted from the specific path pattern.
+ * Also allows access to parent path parameters through index signature.
  *
  * @template Req - Base request type to extend
  * @template Path - URL path pattern with parameter placeholders
@@ -65,8 +66,18 @@ export type PathParams<Path extends string> = string extends Path
  * // For route '/users/:id/posts/:postId'
  * type ExtendedReq = WithPathParams<KoriRequest, '/users/:id/posts/:postId'>;
  * // req.pathParams() returns { id: string; postId: string }
+ *
+ * // When used in nested routes, parent parameters are also accessible:
+ * app.createChild({
+ *   prefix: '/users/:userId',
+ *   configure: (child) => child.get('/posts/:postId', (ctx) => {
+ *     const params = ctx.req.pathParams();
+ *     params.postId;  // string (type-safe, from own path)
+ *     params.userId;  // string | undefined (accessible, from parent path)
+ *   })
+ * })
  * ```
  */
 export type WithPathParams<Req extends KoriRequest, Path extends string> = Omit<Req, 'pathParams'> & {
-  pathParams: () => PathParams<Path>;
+  pathParams: () => PathParams<Path> & Record<string, string | undefined>;
 };


### PR DESCRIPTION
## Summary

This PR enhances the `WithPathParams` type to allow access to parent path parameters in nested routes via an index signature.

## Changes

- Updated `WithPathParams` return type to include `Record<string, string | undefined>`
- Added documentation explaining parent parameter access in nested routes
- Added comprehensive type tests for parent parameter access scenarios

## Benefits

- Child routes can now safely access both their own path parameters (type-safe) and parent path parameters (via index signature)
- Maintains type safety for route-specific parameters while allowing flexible access to parent parameters
- Reflects the runtime behavior where parent parameters are merged into child route contexts



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Path parameter helper now exposes both route-specific and parent parameters, enabling access to ancestor params in nested routes while preserving precise types for known params and optional segments.

* **Tests**
  * Expanded type-level test coverage for nested routes, parent parameter access, and optional parameters, ensuring correct typing and index-signature behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->