### PR TITLE
Fix ks command not found in release workflow

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -8,7 +8,7 @@ pre-commit:
       run: pnpm typecheck
 
     - name: lint
-      run: pnpm ks lint-staged {staged_files}
+      run: pnpm exec ks lint-staged {staged_files}
       glob: '*.{ts,tsx,js}'
       exclude:
         - '*.config.js'

--- a/packages/openapi-plugin/package.json
+++ b/packages/openapi-plugin/package.json
@@ -53,7 +53,7 @@
     "build": "tsdown --tsconfig tsconfig.build.json",
     "test": "vitest run",
     "test:watch": "vitest",
-    "sync:version": "pnpm ks sync-version version/version.ts && prettier --write src/version/version.ts"
+    "sync:version": "pnpm exec ks sync-version version/version.ts && prettier --write src/version/version.ts"
   },
   "peerDependencies": {
     "@korix/kori": "workspace:*",

--- a/packages/openapi-swagger-ui-plugin/package.json
+++ b/packages/openapi-swagger-ui-plugin/package.json
@@ -54,7 +54,7 @@
     "build": "tsdown --tsconfig tsconfig.build.json",
     "test": "vitest run",
     "test:watch": "vitest",
-    "sync:version": "pnpm ks sync-version && prettier --write src/version.ts"
+    "sync:version": "pnpm exec ks sync-version && prettier --write src/version.ts"
   },
   "peerDependencies": {
     "@korix/kori": "workspace:*",

--- a/packages/zod-openapi-plugin/package.json
+++ b/packages/zod-openapi-plugin/package.json
@@ -53,7 +53,7 @@
     "build": "tsdown --tsconfig tsconfig.build.json",
     "test": "vitest run",
     "test:watch": "vitest",
-    "sync:version": "pnpm ks sync-version && prettier --write src/version.ts"
+    "sync:version": "pnpm exec ks sync-version && prettier --write src/version.ts"
   },
   "peerDependencies": {
     "@korix/kori": "workspace:*",


### PR DESCRIPTION
## Problem

The release workflow was failing with `sh: 1: ks: not found` error when running `pnpm changeset:version`.

## Solution

Updated `sync:version` scripts in package.json files to use `pnpm ks` instead of `ks` directly. This ensures that pnpm properly resolves the `ks` binary from the `@korix/script` workspace package.

## Changed Files

- packages/openapi-plugin/package.json
- packages/openapi-swagger-ui-plugin/package.json
- packages/zod-openapi-plugin/package.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized version-sync scripts across plugins to run via pnpm for consistent execution.
  * Updated the OpenAPI plugin's version sync and formatting target to match the new structure.
  * Adjusted Swagger UI and Zod OpenAPI plugin scripts to use pnpm while keeping behavior unchanged.
  * No runtime, UI, or API changes; these updates affect build and maintenance workflows only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->